### PR TITLE
Add max-width to wiki articles

### DIFF
--- a/wiki/templates/wiki/includes/render.html
+++ b/wiki/templates/wiki/includes/render.html
@@ -4,7 +4,7 @@
   <script type="text/javascript" src="{{ STATIC_URL }}wiki/js/article.js"></script>
 {% endaddtoblock %}
 
-<div class="wiki-article">
+<div class="wiki-article" style="margin: 0 auto; max-width: 650px;">
   {% if not preview %}
     {% if article.current_revision %}
       {{ article.get_cached_content }}


### PR DESCRIPTION
Long lines of text makes it harder to focus while reading.
Optimal line length is between 50-75 letters according to
http://baymard.com/blog/line-length-readability

This fix defines a maximum width for the articles, to ensure lines stay
at least under 100 letters even for large monitors, while still keeping
some width for displaying large images etc.

<img width="1440" alt="screenshot 2016-04-18 16 03 06" src="https://cloud.githubusercontent.com/assets/1413267/14606932/b817e498-057f-11e6-812c-277bbb9b146d.png">
