### PR TITLE
Sorting events correctly on the frontpage

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -4,28 +4,23 @@ from django.core.urlresolvers import reverse
 from news.models import Article, Event
 from door.models import DoorStatus
 from datetime import datetime
-from itertools import chain
 from wiki.templatetags import check_user_group as groups
 
 
-def index(request):
-    number_of_news = 3
-
+def index(request, number_of_news=3):
     # Sorts the news to show the events nearest in future and then fill in with the newest articles
+    can_access_internal = groups.has_group(request.user, 'member')
 
-    if groups.has_group(request.user, 'member'):
-        event_list = Event.objects.filter(time_end__gte=datetime.now())[0:number_of_news:-1]
-        article_list = Article.objects.order_by('-pub_date')[0:number_of_news - len(event_list)]
-    else:
-        event_list = Event.objects.filter(time_end__gte=datetime.now(), internal=False)[0:number_of_news:-1]
-        article_list = Article.objects.filter(internal=False).order_by('-pub_date')[0:number_of_news - len(event_list)]
+    event_list = Event.objects.filter(time_end__gte=datetime.now(), internal__lte=can_access_internal).order_by('time_start')
+    article_list = Article.objects.filter(internal__lte=can_access_internal).order_by('-pub_date')
 
-    news_list = list(chain(event_list, article_list))
+    news_list = (list(event_list) + list(article_list))[:number_of_news]
 
     try:
         door_status = DoorStatus.objects.get(name='hackerspace').status
     except DoorStatus.DoesNotExist:
         door_status = True
+
     context = {
         'news_list': news_list,
         'door_status': door_status,

--- a/website/views.py
+++ b/website/views.py
@@ -11,10 +11,10 @@ def index(request, number_of_news=3):
     # Sorts the news to show the events nearest in future and then fill in with the newest articles
     can_access_internal = groups.has_group(request.user, 'member')
 
-    event_list = Event.objects.filter(time_end__gte=datetime.now(), internal__lte=can_access_internal).order_by('time_start')
-    article_list = Article.objects.filter(internal__lte=can_access_internal).order_by('-pub_date')
+    event_list = Event.objects.filter(time_end__gte=datetime.now(), internal__lte=can_access_internal).order_by('time_start')[:number_of_news]
+    article_list = Article.objects.filter(internal__lte=can_access_internal).order_by('-pub_date')[:number_of_news - len(event_list)]
 
-    news_list = (list(event_list) + list(article_list))[:number_of_news]
+    news_list = list(event_list) + list(article_list)
 
     try:
         door_status = DoorStatus.objects.get(name='hackerspace').status


### PR DESCRIPTION
Sorts events by start time and not creation time on the frontpage. Requested by LapOps