### PR TITLE
Fix Django vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==2.0.*
+django<2.1>=2.0.2
 gunicorn
 django-ckeditor
 wiki==0.4b1


### PR DESCRIPTION
Fixes CVE-2018-6188 which affects Django 2.0 prior to 2.0.2