### PR TITLE
Display proper end/start dates if different

### DIFF
--- a/news/templates/news/event.html
+++ b/news/templates/news/event.html
@@ -32,10 +32,19 @@
 					<div class="divider"></div>
 				</div>
 				<div class="col s12 m6">
+					{% if event.time_end|date:"d. F Y" != event.time_start|date:"d. F Y" %}
+					<p><i class="material-icons small">event</i> Fra {{ event.time_start|date:"d. F Y" }}, {{ event.time_start|date:"H:i" }}</p>
+					<p><i class="material-icons small">event_busy</i> Til {{ event.time_end|date:"d. F Y" }}, {{ event.time_end|date:"H:i" }}</p>
+					{% else %}
 					<p><i class="material-icons small">event</i> {{ event.time_start|date:"d. F Y" }}</p>
 					<p><i class="material-icons small">access_time</i> {{ event.time_start|date:"H:i" }} til {{ event.time_end|date:"H:i" }}</p>
+					{% endif %}
 					{% if event.place %}
+						{% if event.place_href %}
 						<p><i class="material-icons small">location_on</i> <a href="{{ event.place_href }}" target="_blank">{{ event.place }}</a></p> 
+						{% else %}
+						<p><i class="material-icons small">location_on</i>{{ event.place }}</p> 
+						{% endif %}
 					{% endif %}
 				</div>
 				<div class="col s12 m6 card-panel z-depth-0 ">


### PR DESCRIPTION
Fixes: #283 

Event med samme start/slutt-dato:
![image](https://user-images.githubusercontent.com/28685654/52708589-d78f5d00-2f8a-11e9-8a78-34e3a2f0405e.png)

Event med ulik start/slutt-dato:
![image](https://user-images.githubusercontent.com/28685654/52708636-ef66e100-2f8a-11e9-8c97-6709b12e067a.png)
