### PR TITLE
Fjern MazeMap API til fordel for hyperlink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,25 @@
 language: python
 
-python:
-  - "3.5.2"
+python: "3.7"
+
+dist: xenial
+
+sudo: true
+
 
 # command to install dependencies
 install: "pip install -r requirements.txt"
 
 # command to run tests
 before_script:
-  - rm -rf wiki/tests
-  - rm -rf wiki/*/*/tests
-  - rm -rf wiki/plugins/haystack
   - python manage.py makemigrations --no-input
   - python manage.py migrate --no-input
 
 
 script:
-- python manage.py test
-- coverage run --source=. manage.py test --no-input
+  - python manage.py test
+  - coverage run --source=. manage.py test --no-input
 
 
 after_success:
-- coveralls
+  - coveralls

--- a/website/templates/website/header.html
+++ b/website/templates/website/header.html
@@ -87,7 +87,7 @@
 					<!-- Dropdown for resurser -->
 					<ul id="resourcedropdown" class="dropdown-content">
 						<li class="tooltipped" data-position="left" data-tooltip="Trykk meg for å se hvor vi befinner oss">
-							<a class="modal-trigger waves-effect hs-green-text" href="#mapModal">Kart</a>
+							<a class="modal-trigger waves-effect hs-green-text" target="_blank" href="http://bit.ly/2Hzw7EO">Kart</a>
 						</li>
 						<li class="tooltipped" data-position="left" data-tooltip="Les om vår organisasjon og grupper her">
 							<a href="{% url 'about' %}">Om Oss</a>
@@ -98,12 +98,6 @@
 			</div>
 		</nav>
 	</div>
-<div id="mapModal" class="modal bottom-sheet">
-	<div class="modal-content">
-		<iframe frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://use.mazemap.com/embed.html#v=1&zlevel=1&campusid=1&sharepoitype=poi&sharepoi=71922" style="border: 1px solid grey; height:35vh; width:100%;"></iframe>
-		<br/><small><a href="https://www.mazemap.com/">Map by MazeMap</a></small>
-	</div>
-</div>
 <script>
 
 


### PR DESCRIPTION
Grunnet dårlige Javascript calls og merkelig embedding system har jeg valgt å fjerne MazeMap embed og heller bare åpne i en ny fane.

Med MazeMap (PageSpeed)
![image](https://user-images.githubusercontent.com/28685654/54768431-70a33a80-4bff-11e9-9fa6-4af103f857de.png)
Uten MazeMap (PageSpeed)
![image](https://user-images.githubusercontent.com/28685654/54768445-7862df00-4bff-11e9-9ef3-f751e2d6ad06.png)


Åpenbart at MazeMap har sine utfordringer med både media og script
![image](https://user-images.githubusercontent.com/28685654/54768618-d2fc3b00-4bff-11e9-87c0-e0811b7cb1ef.png)
De har i tillegg ingen got leverage browser caching.