### PR TITLE
Fix image scaling on smaller devices

### DIFF
--- a/news/templates/news/article.html
+++ b/news/templates/news/article.html
@@ -48,4 +48,18 @@
 	</div>
 	{% endif %}
 </div>
+<script>
+// Prevent ckeditor hard fields to allow responsive images 
+window.addEventListener('DOMContentLoaded', function(event) {
+	var images = document.getElementsByTagName("img");
+	console.log(images);
+	var i;
+
+	for(i = 0; i < images.length; i++) {
+		images[i].className = "responsive-img";
+		images[i].style.height = "";
+	}
+});
+
+</script>
 {% endblock content %}

--- a/news/templates/news/event.html
+++ b/news/templates/news/event.html
@@ -162,6 +162,19 @@ var instance = M.Collapsible.init(collapsible);
 
 var parallax = document.querySelector('.parallax');
 var instance = M.Parallax.init(parallax);
+
+// Prevent ckeditor hard fields to allow responsive images 
+window.addEventListener('DOMContentLoaded', function(event) {
+	var images = document.getElementsByTagName("img");
+	console.log(images);
+	var i;
+
+	for(i = 0; i < images.length; i++) {
+		images[i].className = "responsive-img";
+		images[i].style.height = "";
+	}
+});
+
 </script>
 {% endblock content %}
 


### PR DESCRIPTION
Override ckeditor som injecter, ingen god måte å overstyre på i django-ckeditor så må bli i javascript.