### PR TITLE
Add OpenGraph Metadata for prettier Facebook links

### DIFF
--- a/files/models.py
+++ b/files/models.py
@@ -20,6 +20,9 @@ class Image(models.Model):
     def url(self):
         return '/media/' + str(self.file)
 
+    def abs_url(self):
+        return 'https://www.hackerspace-ntnu.no/media/' + str(self.file)
+
     def thumb_url(self):
         if not self.thumb:
             self.save()

--- a/news/templates/news/article.html
+++ b/news/templates/news/article.html
@@ -1,9 +1,15 @@
 {% extends "website/base.html" %}
 {% load staticfiles %}
 {% load check_user_group %}
-{% block header %}
+{% block head %}
 <link rel="stylesheet" type="text/css" href="{% static 'news/css/news_style.css' %}">
-{% endblock header %}
+{# OpenGraph Metadata #}
+<meta property="og:title" content="{{ article.title }}" />
+<meta property="og:type" content="article" />
+<meta property="og:image" content="{{ article.thumbnail.abs_url }}" />
+<meta property="og:url" content="{{ request.build_absolute_uri }}" />
+{# OpenGraph Metadata End #}
+{% endblock head %}
 
 {% block content %}
 <div class="section no-pad hs-green hide-on-med-and-up">

--- a/news/templates/news/event.html
+++ b/news/templates/news/event.html
@@ -3,6 +3,12 @@
 {% load check_user_group %}
 {% block head %}
 <link rel="stylesheet" type="text/css" href="{% static 'news/css/news_style.css' %}">
+{# OpenGraph Metadata #}
+<meta property="og:title" content="{{ object.title }}" />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="{{ object.thumbnail.abs_url }}" />
+<meta property="og:url" content="{{ request.build_absolute_uri }}" />
+{# OpenGraph Metadata End #}
 {% endblock head %}
 {% block content %}
 <div class="section no-pad hs-green hide-on-med-and-up">


### PR DESCRIPTION
Legg til OPG Metadata for bedre facebook linker og link previews generelt.