### PR TITLE
Added indicator for hidden internal events

### DIFF
--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -75,7 +75,26 @@
 					<div class="col s12 xl12">
 						<ul class="collection with-header z-depth-0">
 							<li class="collection-header">
-								<p class="flow-text"><a class="hs-gray-text" href="{% url 'events:all' %}">Siste Arrangementer</a></p>
+								<p class="flow-text"><a class="hs-gray-text" href="{% url 'events:all' %}">Siste Arrangementer</a>
+
+									{% if hidden_internal_events_count > 0 %}
+
+										<a href="{% url 'social:begin' 'dataporten_feide' %}?next={{ request.path }}">
+
+											<span class="badge new hs-green white-text tooltipped" data-badge-caption=""
+											data-position="top" data-tooltip="Trykk for å logge på og se interne arrangementer">
+												{{hidden_internal_events_count}}
+												<span class="hide-on-med-and-down"> interne skjult</span>
+												<span class="hide-on-small-only hide-on-large-only"> interne arrangementer skjult</span>
+												<span class="hide-on-med-and-up"> skjult</span>
+											</span>
+
+										</a>
+
+									{% endif %}
+
+								</p>
+
 							</li>
 							{% for event in event_list reversed %}
 								<li class="collection-item">

--- a/website/views.py
+++ b/website/views.py
@@ -61,6 +61,12 @@ class IndexView(TemplateView):
         event_list = Event.objects.filter(
             internal__lte=can_access_internal_event).order_by('-time_start')[:5:-1]
 
+        # Determine number of hidden internal events
+        if not can_access_internal_event:
+            hidden_internal_events_count = len(Event.objects.filter(internal=True))
+        else:
+            hidden_internal_events_count = 0
+
         # Get five articles
         article_list = Article.objects.filter(
             internal__lte=can_access_internal_article).order_by('-pub_date')[:5]
@@ -91,12 +97,14 @@ class IndexView(TemplateView):
         context = {
             'article_list': article_list,
             'event_list': event_list,
+            'hidden_internal_events_count': hidden_internal_events_count,
             'door_status': door_status,
             'app_start_date': app_start_date,
             'app_end_date': app_end_date,
             'is_application': is_application,
             'index_cards': Card.objects.all(),
             'current_date': current_date
+
         }
 
         return context


### PR DESCRIPTION
Feature: #364 

Forkorter teksten trinnvis i et forsøk på å håndtere ulike skjermstørrelser:

- Large:
![Skjermbilde 2019-11-08 kl  00 04 46](https://user-images.githubusercontent.com/24361490/68435378-744df680-01bb-11ea-8347-9cc766755c24.png)

- Medium (større siden det nå er én kolonne i bredden):
![Skjermbilde 2019-11-08 kl  00 04 59](https://user-images.githubusercontent.com/24361490/68435390-7a43d780-01bb-11ea-880e-ab52f15e9112.png)

- Small:
![Skjermbilde 2019-11-08 kl  00 05 06](https://user-images.githubusercontent.com/24361490/68435397-7d3ec800-01bb-11ea-80bd-c17b8ba6cb8e.png)
