### PR TITLE
Added internal indicator to /news, /events and articles in index 

### DIFF
--- a/news/static/news/css/news_style.css
+++ b/news/static/news/css/news_style.css
@@ -69,3 +69,9 @@
 strong {
 	font-weight: bolder !important;
 }
+.listview-indicator{
+	padding: 14px 20px
+}
+.listview-indicator .material-icons {
+	padding: 0 10px 0 0
+}

--- a/news/templates/news/events.html
+++ b/news/templates/news/events.html
@@ -12,9 +12,9 @@
 				<h4>
 					Arrangementer
 				</h4>
-			</div>
-			<div class="col s12">
-				{% include "news/internal_indicator.html" with indicator=internal_events_indicator %}
+				{% if indicator_text %}
+				{% include "news/internal_indicator.html" %}
+				{% endif %}
 			</div>
 		</div>
 	</div>

--- a/news/templates/news/events.html
+++ b/news/templates/news/events.html
@@ -7,12 +7,14 @@
 {% block content %}
 <div class="section hs-green">
 	<div class="container">
-		<div class="row white-text">
+		<div class="row white-text valign-wrapper">
 			<div class="col s12">
 				<h4>
 					Arrangementer
-					{% include "news/internal_indicator.html" with indicator=internal_events_indicator %}
 				</h4>
+			</div>
+			<div class="col s12">
+				{% include "news/internal_indicator.html" with indicator=internal_events_indicator %}
 			</div>
 		</div>
 	</div>

--- a/news/templates/news/events.html
+++ b/news/templates/news/events.html
@@ -9,7 +9,10 @@
 	<div class="container">
 		<div class="row white-text">
 			<div class="col s12">
-				<h4>Arrangementer</h4>
+				<h4>
+					Arrangementer
+					{% include "news/internal_indicator.html" with indicator=internal_events_indicator %}
+				</h4>
 			</div>
 		</div>
 	</div>
@@ -19,12 +22,6 @@
 {% regroup object_list|dictsort:"is_past_due" by is_past_due as status_list %}
 <div class="section block">
 	<div class="container">
-	<div class="row">
-		<div class="col s12">
-			<p>Husk å logge på din konto for å se internarrangementer</p>
-			<div class="divider"></div>
-		</div>
-	</div>
 	{% for status in status_list %}
 		<div class="row">
 			<div class="col s12">

--- a/news/templates/news/events.html
+++ b/news/templates/news/events.html
@@ -12,9 +12,6 @@
 				<h4>
 					Arrangementer
 				</h4>
-				{% if indicator_text %}
-				{% include "news/internal_indicator.html" %}
-				{% endif %}
 			</div>
 		</div>
 	</div>
@@ -24,17 +21,21 @@
 {% regroup object_list|dictsort:"is_past_due" by is_past_due as status_list %}
 <div class="section block">
 	<div class="container">
-	{% for status in status_list %}
-		<div class="row">
-			<div class="col s12">
-				<h5 class="subheader">{{ status.grouper|slice:"1:" }}</h5>
-				<div class="divider"></div>
+		{% if indicator_text %}
+			{% include "news/internal_indicator.html" %}
+		{% endif %}
+		{% for status in status_list %}
+			<div class="row">
+				<div class="col s12">
+					<h5 class="subheader">{{ status.grouper|slice:"1:" }}</h5>
+					<div class="divider"></div>
+				</div>
 			</div>
-		</div>
-		{% for event in status.list %}
-			{% include 'news/_event-list-element.html' with status=status.grouper %}
+			{% for event in status.list %}
+				{% include 'news/_event-list-element.html' with status=status.grouper %}
+			{% endfor %}
 		{% endfor %}
-	{% endfor %}
+	</div>
 </div>
 {% include 'website/_paginator.html' %}
 {% endblock %}

--- a/news/templates/news/internal_indicator.html
+++ b/news/templates/news/internal_indicator.html
@@ -1,7 +1,7 @@
 {% if indicator.count > 0 %}
 
   <a href="{% url 'social:begin' 'dataporten_feide' %}?next={{ request.path }}">
-    <span class="white-text new hs-gray badge tooltipped" data-badge-caption=""
+    <div class="white-text hs-gray tooltipped card-panel z-depth-0 right" style="margin:0;padding:12px"
     data-position="bottom"  data-tooltip="{{indicator.tooltip_text}}">
       {{indicator.count}}
       {% if indicator.count > 1 %}
@@ -13,6 +13,7 @@
         <span class="hide-on-small-only hide-on-large-only"> {{indicator.badge_text.singular.medium}}</span>
         <span class="hide-on-med-and-up"> {{indicator.badge_text.singular.small}}</span>
       {% endif %}
+    </div>
   </a>
 
 {% endif %}

--- a/news/templates/news/internal_indicator.html
+++ b/news/templates/news/internal_indicator.html
@@ -1,8 +1,8 @@
 <a href="{% url 'social:begin' 'dataporten_feide' %}?next={{ request.path }}">
-	<div class="row valign-wrapper">
-		<div class="col s12">
-			<div class="card-panel hs-gray-text white tooltipped z-depth-0" data-position="bottom"  data-tooltip="Trykk for å logge inn">
-				<i class="material-icons blue-text text-lighten-3">info</i>
+	<div class="row">
+		<div class="col">
+			<div class="card-panel white-text hs-green tooltipped z-depth-0 valign-wrapper" style="padding:14px 20px" data-position="bottom"  data-tooltip="Trykk for å logge inn">
+				<i class="material-icons white-text text-lighten-3" style="padding:0 10px 0 0">info</i>
 				<span> {{ indicator_text }}</span>
 			</div>
 		</div>

--- a/news/templates/news/internal_indicator.html
+++ b/news/templates/news/internal_indicator.html
@@ -1,0 +1,16 @@
+{% if indicator.count > 0 %}
+
+  <a href="{% url 'social:begin' 'dataporten_feide' %}?next={{ request.path }}">
+    <span class="white-text new hs-gray badge tooltipped" data-badge-caption=""
+    data-position="bottom"  data-tooltip="{{indicator.tooltip_text}}">
+      {{indicator.count}}
+      {% if indicator.count > 1 %}
+        <span class="hide-on-small-only"> {{indicator.badge_text.plural.large}}</span>
+        <span class="hide-on-med-and-up"> {{indicator.badge_text.plural.medium}}</span>
+      {% else %}
+        <span class="hide-on-small-only"> {{indicator.badge_text.singular.large}}</span>
+        <span class="hide-on-med-and-up"> {{indicator.badge_text.singular.medium}}</span>
+      {% endif %}
+  </a>
+
+{% endif %}

--- a/news/templates/news/internal_indicator.html
+++ b/news/templates/news/internal_indicator.html
@@ -1,19 +1,10 @@
-{% if indicator.count > 0 %}
-
-  <a href="{% url 'social:begin' 'dataporten_feide' %}?next={{ request.path }}">
-    <div class="white-text hs-gray tooltipped card-panel z-depth-0 right" style="margin:0;padding:12px"
-    data-position="bottom"  data-tooltip="{{indicator.tooltip_text}}">
-      {{indicator.count}}
-      {% if indicator.count > 1 %}
-        <span class="hide-on-med-and-down"> {{indicator.badge_text.plural.large}}</span>
-        <span class="hide-on-small-only hide-on-large-only"> {{indicator.badge_text.plural.medium}}</span>
-        <span class="hide-on-med-and-up"> {{indicator.badge_text.plural.small}}</span>
-      {% else %}
-        <span class="hide-on-med-and-down"> {{indicator.badge_text.singular.large}}</span>
-        <span class="hide-on-small-only hide-on-large-only"> {{indicator.badge_text.singular.medium}}</span>
-        <span class="hide-on-med-and-up"> {{indicator.badge_text.singular.small}}</span>
-      {% endif %}
-    </div>
-  </a>
-
-{% endif %}
+<a href="{% url 'social:begin' 'dataporten_feide' %}?next={{ request.path }}">
+	<div class="row valign-wrapper">
+		<div class="col s12">
+			<div class="card-panel hs-gray-text white tooltipped z-depth-0" data-position="bottom"  data-tooltip="Trykk for å logge inn">
+				<i class="material-icons blue-text text-lighten-3">info</i>
+				<span> {{ indicator_text }}</span>
+			</div>
+		</div>
+	</div>
+</a>

--- a/news/templates/news/internal_indicator.html
+++ b/news/templates/news/internal_indicator.html
@@ -1,10 +1,10 @@
-<a href="{% url 'social:begin' 'dataporten_feide' %}?next={{ request.path }}">
-	<div class="row">
-		<div class="col">
-			<div class="card-panel white-text hs-green tooltipped z-depth-0 valign-wrapper" style="padding:14px 20px" data-position="bottom"  data-tooltip="Trykk for å logge inn">
-				<i class="material-icons white-text text-lighten-3" style="padding:0 10px 0 0">info</i>
+<div class="row">
+	<div class="col">
+		<a href="{% url 'social:begin' 'dataporten_feide' %}?next={{ request.path }}">
+			<div class="listview-indicator card-panel white-text hs-green tooltipped z-depth-0 valign-wrapper" data-position="bottom"  data-tooltip="Trykk for å logge inn">
+				<i class="material-icons white-text text-lighten-3">info</i>
 				<span> {{ indicator_text }}</span>
 			</div>
-		</div>
+		</a>
 	</div>
-</a>
+</div>

--- a/news/templates/news/internal_indicator.html
+++ b/news/templates/news/internal_indicator.html
@@ -5,11 +5,13 @@
     data-position="bottom"  data-tooltip="{{indicator.tooltip_text}}">
       {{indicator.count}}
       {% if indicator.count > 1 %}
-        <span class="hide-on-small-only"> {{indicator.badge_text.plural.large}}</span>
-        <span class="hide-on-med-and-up"> {{indicator.badge_text.plural.medium}}</span>
+        <span class="hide-on-med-and-down"> {{indicator.badge_text.plural.large}}</span>
+        <span class="hide-on-small-only hide-on-large-only"> {{indicator.badge_text.plural.medium}}</span>
+        <span class="hide-on-med-and-up"> {{indicator.badge_text.plural.small}}</span>
       {% else %}
-        <span class="hide-on-small-only"> {{indicator.badge_text.singular.large}}</span>
-        <span class="hide-on-med-and-up"> {{indicator.badge_text.singular.medium}}</span>
+        <span class="hide-on-med-and-down"> {{indicator.badge_text.singular.large}}</span>
+        <span class="hide-on-small-only hide-on-large-only"> {{indicator.badge_text.singular.medium}}</span>
+        <span class="hide-on-med-and-up"> {{indicator.badge_text.singular.small}}</span>
       {% endif %}
   </a>
 

--- a/news/templates/news/news.html
+++ b/news/templates/news/news.html
@@ -13,9 +13,6 @@
 				<h4>
 					Nyheter
 				</h4>
-				{% if indicator_text %}
-				{% include "news/internal_indicator.html" %}
-				{% endif %}
 			</div>
 		</div>
 	</div>
@@ -23,6 +20,9 @@
 {% include "news/_list_admin_banner.html" %}
 <div class="section">
 	<div class="container">
+		{% if indicator_text %}
+			{% include "news/internal_indicator.html" %}
+		{% endif %}
 		<div class="row">
 			<div class="col s12">
 				{% for news in object_list %}

--- a/news/templates/news/news.html
+++ b/news/templates/news/news.html
@@ -8,12 +8,14 @@
 {% block content %}
 <div class="section hs-green">
 	<div class="container">
-		<div class="row white-text">
+		<div class="row white-text valign-wrapper">
 			<div class="col s12">
 				<h4>
 					Nyheter
-					{% include "news/internal_indicator.html" with indicator=internal_articles_indicator %}
 				</h4>
+			</div>
+			<div class="col s12">
+				{% include "news/internal_indicator.html" with indicator=internal_articles_indicator %}
 			</div>
 		</div>
 	</div>

--- a/news/templates/news/news.html
+++ b/news/templates/news/news.html
@@ -10,7 +10,10 @@
 	<div class="container">
 		<div class="row white-text">
 			<div class="col s12">
-				<h4>Nyheter</h4>
+				<h4>
+					Nyheter
+					{% include "news/internal_indicator.html" with indicator=internal_articles_indicator %}
+				</h4>
 			</div>
 		</div>
 	</div>
@@ -72,7 +75,7 @@
 			<li class="active hs-green"><a href="#!">{{ page_obj.number }}</a></li>
 			{% else %}
 			<li class=""><a href="?page={{ page }}">{{ page }}</a></li>
-			{% endif %}	
+			{% endif %}
 			{% endfor %}
 
 			{% if page_obj.has_next %}

--- a/news/templates/news/news.html
+++ b/news/templates/news/news.html
@@ -8,14 +8,14 @@
 {% block content %}
 <div class="section hs-green">
 	<div class="container">
-		<div class="row white-text valign-wrapper">
+		<div class="row valign-wrapper white-text">
 			<div class="col s12">
 				<h4>
 					Nyheter
 				</h4>
-			</div>
-			<div class="col s12">
-				{% include "news/internal_indicator.html" with indicator=internal_articles_indicator %}
+				{% if indicator_text %}
+				{% include "news/internal_indicator.html" %}
+				{% endif %}
 			</div>
 		</div>
 	</div>

--- a/news/views.py
+++ b/news/views.py
@@ -52,27 +52,9 @@ class EventListView(ListView):
         # Determine number of hidden internal events
         if not self.request.user.has_perm('news.can_view_internal_event'):
             upcoming_internal_events_count = len(Event.objects.filter(internal=True).filter(time_start__gte=current_date))
-        else:
-            upcoming_internal_events_count = 0
+            return "Du har ikke rettigheter til å se interne arrangementer."
 
-        badge_text = {
-            "plural":{
-                "large":"interne arrangementer skjult",
-                "medium":"interne skjult",
-                "small":"skjult"
-            },
-            "singular":{
-                "large":"internt arrangement skjult",
-                "medium":"internt skjult",
-                "small":"skjult"
-            }
-        }
-
-        return {
-            'count': upcoming_internal_events_count,
-            'badge_text': badge_text,
-            'tooltip_text': "Trykk for å logge på og se interne arrangementer"
-        }
+        return None
 
     def get_queryset(self):
         if self.request.user.has_perm('news.can_view_internal_event'):
@@ -84,7 +66,7 @@ class EventListView(ListView):
 
         context = super().get_context_data(**kwargs)
 
-        context['internal_events_indicator'] = self.get_internal_events_indicator()
+        context['indicator_text'] = self.get_internal_events_indicator()
 
         return context
 
@@ -131,27 +113,10 @@ class ArticleListView(ListView):
         # Determine number of hidden internal articles
         if not self.request.user.has_perm('news.can_view_internal_article'):
             internal_articles_count = len(Article.objects.filter(internal=True))
-        else:
-            internal_articles_count = 0
+            return "Du har ikke rettigheter til å se interne artikler."
 
-        badge_text = {
-            "plural":{
-                "large":"interne artikler skjult",
-                "medium":"interne skjult",
-                "small":"skjult"
-            },
-            "singular":{
-                "large":"intern artikkel skjult",
-                "medium":"intern skjult",
-                "small":"skjult"
-            }
-        }
+        return None
 
-        return {
-            'count': internal_articles_count,
-            'badge_text': badge_text,
-            'tooltip_text': "Trykk for å logge på og se interne artikler"
-        }
 
     def get_queryset(self):
         if self.request.user.has_perm("news.can_view_internal_article"):
@@ -163,7 +128,7 @@ class ArticleListView(ListView):
 
         context = super().get_context_data(**kwargs)
 
-        context['internal_articles_indicator'] = self.get_internal_articles_indicator()
+        context['indicator_text'] = self.get_internal_articles_indicator()
 
         return context
 

--- a/news/views.py
+++ b/news/views.py
@@ -45,11 +45,48 @@ class EventListView(ListView):
     template_name = "news/events.html"
     paginate_by = 10
 
+    def get_internal_events_indicator(self):
+
+        current_date = datetime.now()
+
+        # Determine number of hidden internal events
+        if not self.request.user.has_perm('news.can_view_internal_event'):
+            upcoming_internal_events_count = len(Event.objects.filter(internal=True).filter(time_start__gte=current_date))
+        else:
+            upcoming_internal_events_count = 0
+
+        badge_text = {
+            "plural":{
+                "large":"interne arrangementer skjult",
+                "medium":"interne skjult",
+                "small":"skjult"
+            },
+            "singular":{
+                "large":"internt arrangement skjult",
+                "medium":"internt skjult",
+                "small":"skjult"
+            }
+        }
+
+        return {
+            'count': upcoming_internal_events_count,
+            'badge_text': badge_text,
+            'tooltip_text': "Trykk for å logge på og se interne arrangementer"
+        }
+
     def get_queryset(self):
         if self.request.user.has_perm('news.can_view_internal_event'):
             return Event.objects.order_by('-time_end')
         else:
             return Event.objects.filter(internal=False).order_by('-time_end')
+
+    def get_context_data(self, **kwargs):
+
+        context = super().get_context_data(**kwargs)
+
+        context['internal_events_indicator'] = self.get_internal_events_indicator()
+
+        return context
 
 
 class EventAttendeeEditView(PermissionRequiredMixin, UpdateView):
@@ -89,11 +126,47 @@ class ArticleListView(ListView):
     template_name = "news/news.html"
     paginate_by = 10
 
+    def get_internal_articles_indicator(self):
+
+        # Determine number of hidden internal articles
+        if not self.request.user.has_perm('news.can_view_internal_article'):
+            internal_articles_count = len(Article.objects.filter(internal=True))
+        else:
+            internal_articles_count = 0
+
+        badge_text = {
+            "plural":{
+                "large":"interne artikler skjult",
+                "medium":"interne skjult",
+                "small":"skjult"
+            },
+            "singular":{
+                "large":"intern artikkel skjult",
+                "medium":"intern skjult",
+                "small":"skjult"
+            }
+        }
+
+        return {
+            'count': internal_articles_count,
+            'badge_text': badge_text,
+            'tooltip_text': "Trykk for å logge på og se interne artikler"
+        }
+
     def get_queryset(self):
         if self.request.user.has_perm("news.can_view_internal_article"):
             return Article.objects.order_by('-pub_date')
         else:
             return Article.objects.filter(internal=False).order_by('-pub_date')
+
+    def get_context_data(self, **kwargs):
+
+        context = super().get_context_data(**kwargs)
+
+        context['internal_articles_indicator'] = self.get_internal_articles_indicator()
+
+        return context
+
 
 
 class ArticleView(DetailView):

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -61,7 +61,11 @@
 						<ul class="collection with-header z-depth-0">
 							<li class="collection-header">
 								<div>
-									<p class="flow-text"><a class="hs-gray-text" href="{% url 'news:all' %}">Siste Nytt</a></p>
+
+									<p class="flow-text"><a class="hs-gray-text" href="{% url 'news:all' %}">Siste Nytt</a>
+										{% include "website/internal_indicator.html" with indicator=internal_articles_indicator %}
+									</p>
+
 								</div>
 							</li>
 							{% for article in article_list %}
@@ -75,30 +79,9 @@
 					<div class="col s12 xl12">
 						<ul class="collection with-header z-depth-0">
 							<li class="collection-header">
+
 								<p class="flow-text"><a class="hs-gray-text" href="{% url 'events:all' %}">Siste Arrangementer</a>
-
-									{% if upcoming_internal_events_count > 0 %}
-
-										<a href="{% url 'social:begin' 'dataporten_feide' %}?next={{ request.path }}">
-
-											<span class="badge new hs-green white-text tooltipped" data-badge-caption=""
-											data-position="top" data-tooltip="Trykk for å logge på og se interne arrangementer">
-												{{upcoming_internal_events_count}}
-												{% if upcoming_internal_events_count > 1 %}
-													<span class="hide-on-med-and-down"> interne skjult</span>
-													<span class="hide-on-small-only hide-on-large-only"> interne arrangementer skjult</span>
-													<span class="hide-on-med-and-up"> skjult</span>
-												{% else %}
-													<span class="hide-on-med-and-down"> internt skjult</span>
-													<span class="hide-on-small-only hide-on-large-only"> internt arrangement skjult</span>
-													<span class="hide-on-med-and-up"> skjult</span>
-												{% endif %}
-											</span>
-
-										</a>
-
-									{% endif %}
-
+									{% include "website/internal_indicator.html" with indicator=internal_events_indicator %}
 								</p>
 
 							</li>

--- a/website/templates/website/internal_indicator.html
+++ b/website/templates/website/internal_indicator.html
@@ -1,0 +1,21 @@
+{% if indicator.count > 0 %}
+
+  <a href="{% url 'social:begin' 'dataporten_feide' %}?next={{ request.path }}">
+
+    <span class="badge new hs-green white-text tooltipped" data-badge-caption=""
+    data-position="top" data-tooltip="{{indicator.tooltip_text}}">
+      {{indicator.count}}
+      {% if indicator.count > 1 %}
+        <span class="hide-on-med-and-down"> {{indicator.badge_text.plural.large}}</span>
+        <span class="hide-on-small-only hide-on-large-only"> {{indicator.badge_text.plural.medium}}</span>
+        <span class="hide-on-med-and-up"> {{indicator.badge_text.plural.small}}</span>
+      {% else %}
+        <span class="hide-on-med-and-down"> {{indicator.badge_text.singular.large}}</span>
+        <span class="hide-on-small-only hide-on-large-only">  {{indicator.badge_text.singular.medium}}</span>
+        <span class="hide-on-med-and-up"> {{indicator.badge_text.singular.small}}</span>
+      {% endif %}
+    </span>
+
+  </a>
+
+{% endif %}

--- a/website/templates/website/internal_indicator.html
+++ b/website/templates/website/internal_indicator.html
@@ -6,12 +6,12 @@
     data-position="top" data-tooltip="{{indicator.tooltip_text}}">
       {{indicator.count}}
       {% if indicator.count > 1 %}
-        <span class="hide-on-med-and-down"> {{indicator.badge_text.plural.large}}</span>
-        <span class="hide-on-small-only hide-on-large-only"> {{indicator.badge_text.plural.medium}}</span>
+        <span class="hide-on-med-and-down"> {{indicator.badge_text.plural.medium}}</span>
+        <span class="hide-on-small-only hide-on-large-only"> {{indicator.badge_text.plural.large}}</span>
         <span class="hide-on-med-and-up"> {{indicator.badge_text.plural.small}}</span>
       {% else %}
-        <span class="hide-on-med-and-down"> {{indicator.badge_text.singular.large}}</span>
-        <span class="hide-on-small-only hide-on-large-only">  {{indicator.badge_text.singular.medium}}</span>
+        <span class="hide-on-med-and-down"> {{indicator.badge_text.singular.medium}}</span>
+        <span class="hide-on-small-only hide-on-large-only">  {{indicator.badge_text.singular.large}}</span>
         <span class="hide-on-med-and-up"> {{indicator.badge_text.singular.small}}</span>
       {% endif %}
     </span>

--- a/website/views.py
+++ b/website/views.py
@@ -61,13 +61,13 @@ class IndexView(TemplateView):
 
         badge_text = {
             "plural":{
-                "large":"interne skjult",
-                "medium":"interne artikler skjult",
+                "large":"interne artikler skjult",
+                "medium":"interne skjult",
                 "small":"skjult"
             },
             "singular":{
-                "large":"intern skjult",
-                "medium":"intern artikkel skjult",
+                "large":"intern artikkel skjult",
+                "medium":"intern skjult",
                 "small":"skjult"
             }
         }
@@ -90,13 +90,13 @@ class IndexView(TemplateView):
 
         badge_text = {
             "plural":{
-                "large":"interne skjult",
-                "medium":"interne arrangementer skjult",
+                "large":"interne arrangementer skjult",
+                "medium":"interne skjult",
                 "small":"skjult"
             },
             "singular":{
-                "large":"intern skjult",
-                "medium":"internt arrangement skjult",
+                "large":"internt arrangement skjult",
+                "medium":"internt skjult",
                 "small":"skjult"
             }
         }


### PR DESCRIPTION
Extension of #438 as suggested by @camelgod 

Also introduced partial code-reuse with `internal_indicator.html` template and `indicator` variable in `/website` and `/news`.