### PR TITLE
Added pending icon on event registrations before event start

### DIFF
--- a/news/templates/news/_event_admin_menu.html
+++ b/news/templates/news/_event_admin_menu.html
@@ -52,6 +52,12 @@
 								</span>
 								{% endif %}
 
+							{% else %}
+
+							<span class="secondary-content tooltipped" data-position="top" data-tooltip="Venter på arrangementstart">
+								⌛
+							</span>
+
 							{% endif %}
 
 						</li>


### PR DESCRIPTION
Unregistered attendance before event start should not be punished with a devil emoji. Will now display a pending emoji as long as the event has not started