### PR TITLE
Redirect TOS accept to originally visited path

### DIFF
--- a/website/templates/website/tos-returningls.html
+++ b/website/templates/website/tos-returningls.html
@@ -20,7 +20,7 @@
 		<p class="flow-text">I forbindelse med nye lovverk (vektlagt er Personvernforordningen, også kjent som GDPR) og formalisering internt i organisasjonen, ønsker vi å informere og innhente nytt samtykke om bruk av personvern i Hackerspace.</p>
 
 		<p class="flow-text">Vennligst bekreft at du har lest og godtar informasjonen og samtykker til vilkårene tilgjengelig <a href="/tos/" target="_blank">her</a></p>
-		<a class="btn btn-large hs-green" href="/tos/accept">JEG HAR LEST, FORSTÅTT OG GODTAR VILKÅRENE</a>
+		<a class="btn btn-large hs-green" href="{% url 'tos-accept' %}">JEG HAR LEST, FORSTÅTT OG GODTAR VILKÅRENE</a>
 	</div>
 </div>
 


### PR DESCRIPTION
Fixes #459 

Stores users path before TOS redirect in a temporary session variable. This is later accessed to return the user to their originally visited path.