### PR TITLE
Replaced existing admin page link with admin panel link in header menu

### DIFF
--- a/website/templates/website/header.html
+++ b/website/templates/website/header.html
@@ -98,11 +98,10 @@
 						<li class="tooltipped" data-position="left" data-tooltip="Les om vår organisasjon og grupper her">
 							<a href="{% url 'about' %}">Om Oss</a>
 						</li>
-						{% if perms.userprofile.can_view_admin %}
+						{% if user.is_staff %}
 						<li class="tooltipped" data-position="left" data-tooltip="Administratorpanel for viktige folk">
-							<a href="{% url 'admin' %}">Administrator</a>
+							<a href="/admin">Adminpanel</a>
 						</li>
-
 						{% endif %}
 					</ul>
 				</ul>


### PR DESCRIPTION
Before this change the admin menu item linked to an admin panel page that offered minimal functionality

![Skjermbilde 2020-02-26 kl  18 30 26](https://user-images.githubusercontent.com/24361490/75370879-1b1ee580-58c6-11ea-8e89-9f3cea6a7061.png)
![Skjermbilde 2020-02-26 kl  18 23 26](https://user-images.githubusercontent.com/24361490/75370357-3dfcca00-58c5-11ea-9959-b09faf1ca157.png)

With this change the menu item now links to the django admin panel at /admin

![Skjermbilde 2020-02-26 kl  18 30 08](https://user-images.githubusercontent.com/24361490/75370869-1823f500-58c6-11ea-822f-d925189cb6b5.png)

![Skjermbilde 2020-02-26 kl  18 31 44](https://user-images.githubusercontent.com/24361490/75370984-47d2fd00-58c6-11ea-8bcd-9869a4b66714.png)