### PR TITLE
Added button to create TOS based on existing one

### DIFF
--- a/userprofile/templates/userprofile/create_tos.html
+++ b/userprofile/templates/userprofile/create_tos.html
@@ -12,7 +12,7 @@
 	<div class="container">
 		<div class="row">
 			<div class="col s12">
-				<h4>Rediger TOS</h4>
+				<h4>Ny TOS</h4>
 			</div>
 		</div>
 	</div>

--- a/userprofile/templates/userprofile/tos_detail.html
+++ b/userprofile/templates/userprofile/tos_detail.html
@@ -6,6 +6,11 @@
         <div class="row center-align">
           <h3>Vilkår for bruk av nettside</h3>
           <p>Oppdatert {{ termsofservice.pub_date }}</p>
+          {% if perms.userprofile.add_termsofservice %}
+            <a class="btn-flat white" href="{% url 'tos-create-id' termsofservice.id %}"><i class="material-icons">edit</i>
+              Ny TOS basert på denne
+            </a>
+          {% endif %}
         </div>
     </div>
 </div>

--- a/userprofile/views.py
+++ b/userprofile/views.py
@@ -79,6 +79,7 @@ class TermsOfServiceView(DetailView):
 
 class MostRecentTermsOfServiceView(RedirectView):
 
+    # Redirect url without primary key to detail view of the latest TOS
     def get_redirect_url(self, *args, **kwargs):
         termsofservice = TermsOfService.objects.order_by('-pub_date').first()
         return reverse('tos-details', kwargs={'pk': termsofservice.id})
@@ -88,9 +89,21 @@ class TermsOfServiceCreateView(PermissionRequiredMixin, SuccessMessageMixin, Cre
 
     model = TermsOfService
     fields = ['text', 'pub_date']
-    template_name = "userprofile/edit_tos.html"
+    template_name = "userprofile/create_tos.html"
     permission_required = "userprofile.add_termsofservice"
     success_message = "TOS er opprettet"
 
     def get_success_url(self):
+
+        # Redirect to detail view of newly created TOS
         return reverse('tos-details', kwargs={'pk': self.object.id})
+
+    def get_initial(self):
+        initial = super().get_initial()
+
+        # Check if new TOS should be based on an old TOS
+        if('pk' in self.kwargs):
+            # Prepopulate new TOS with text from old TOS given in URL
+            initial['text'] = TermsOfService.objects.get(id=self.kwargs['pk']).text
+
+        return initial

--- a/website/templates/website/header.html
+++ b/website/templates/website/header.html
@@ -1,8 +1,7 @@
 {% load static %}
 {% if request.user.is_authenticated and not request.user.profile.has_accepted_most_recent_tos %}
-	{# Checks if path should display TOS prompt. Slicing covers paths for all tos objects #}
-	{% if request.path == "/tos/returning-user/" or request.path == "/tos/" or request.path|slice:":5" == "/tos/" %}
-	{% else %}
+	<!-- Checks if path should display TOS prompt. Slice check disables TOS display for all tos-related pages -->
+	{% if request.path != "/tos/returning-user/" and request.path|slice:":5" != "/tos/" %}
 		<meta http-equiv="refresh" content="1;url=/tos/returning-user/">
 	{% endif %}
 {% endif %}

--- a/website/urls.py
+++ b/website/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('tos/returning-user/', AcceptTosView.as_view(), name='tos-returningls'),
     path('tos/accept/', AcceptTosRedirectView.as_view(), name='tos-accept'),
     path('tos/create/', TermsOfServiceCreateView.as_view(), name='tos-create'),
+    path('tos/create/<int:pk>/', TermsOfServiceCreateView.as_view(), name='tos-create-id'),
     path('tos/<int:pk>/', TermsOfServiceView.as_view(), name='tos-details'),
     path('news/', include('news.urls')),
     path('events/', include('news.event_urls')),


### PR DESCRIPTION
Added create TOS button in TOS detail view.

![Skjermbilde 2020-02-26 kl  18 44 14](https://user-images.githubusercontent.com/24361490/75372764-47883100-58c9-11ea-99dc-7672b8051efd.png)

When create TOS button is clicked the text form is initially filled with the text from the latest existing TOS. This emphasises that a TOS cannot be edited, only created, while still being able to keep as much text as wanted.

![Skjermbilde 2020-02-26 kl  18 49 13](https://user-images.githubusercontent.com/24361490/75372376-bdd86380-58c8-11ea-871a-2ce15f7b8b06.png)
