### PR TITLE
Added better support for long names in event attendance list, and other attendance enhancements

### DIFF
--- a/news/static/news/css/news_style.css
+++ b/news/static/news/css/news_style.css
@@ -3,8 +3,23 @@
 }
 .ingress {
 	font-weight: 700;
-
 }
+
+.event-attendee-row{
+	display:table;
+	width:100%;
+}
+
+.event-attendee-name{
+	display:table-cell;
+}
+
+.event-attendee-icon{
+	display:table-cell;
+	vertical-align:middle;
+	padding-left: 1em;
+}
+
 @media only screen and (max-width: 600px) {
 	.cut-top {
 		margin-top: -96px !important;

--- a/news/templates/news/_event_admin_menu.html
+++ b/news/templates/news/_event_admin_menu.html
@@ -34,32 +34,24 @@
 			</div>
 			<div class="col s12 m12 l6">
 
-				<table>
-				<tbody>
-				<tr>
-					<td style="max-width:0;overflow:hidden">Testingteinstfevffefesinitne hurbvefuwi efvwefwef</td>
-					<td style="width:1px;">😈</td>
-				</tr>
-				</tbody>
-				</table>
-
 				<ul class="collection with-header">
 
 					<li class="collection-header">
 						<h4>Alle påmeldte</h4>
 					</li>
+					
 					{% for user in event.registration_list %}
 
 					{% if not user.is_waitlisted %}
-					<li class="collection-item" style="display:table;width:100%">
+					<li class="collection-item event-attendee-row">
 
-						<a style="height:100%;display:table-cell;overflow:hidden;" href="{% url 'userprofile:profile_by_id' user.user.id %}">
+						<a class="event-attendee-name" href="{% url 'userprofile:profile_by_id' user.user.id %}">
 							{{ user.user.get_full_name }}
 						</a>
 
 						{% if event.is_past_start %}
 
-						<a style="height:100%;display:table-cell;vertical-align:middle;" href="/events/{{ event.id }}/attended">
+						<a class="event-attendee-icon" href="/events/{{ event.id }}/attended">
 
 							{% if user.attended %}
 							<span class="secondary-content tooltipped" data-position="top" data-tooltip="Oppmøte registrert!">

--- a/news/templates/news/_event_admin_menu.html
+++ b/news/templates/news/_event_admin_menu.html
@@ -22,7 +22,9 @@
 		<div class="row">
 			<div class="col s12 m12 l6">
 				<ul class="collection with-header">
-					<li class="collection-header"><h4>Venteliste</h4></li>
+					<li class="collection-header">
+						<h4>Venteliste</h4>
+					</li>
 					{% for user in event.wait_list %}
 					<li class="collection-item">{{ user.get_full_name }}</li>
 					{% empty %}
@@ -31,44 +33,59 @@
 				</ul>
 			</div>
 			<div class="col s12 m12 l6">
+
+				<table>
+				<tbody>
+				<tr>
+					<td style="max-width:0;overflow:hidden">Testingteinstfevffefesinitne hurbvefuwi efvwefwef</td>
+					<td style="width:1px;">😈</td>
+				</tr>
+				</tbody>
+				</table>
+
 				<ul class="collection with-header">
+
 					<li class="collection-header">
 						<h4>Alle påmeldte</h4>
 					</li>
 					{% for user in event.registration_list %}
 
-						{% if not user.is_waitlisted %}
-						<li class="collection-item">
+					{% if not user.is_waitlisted %}
+					<li class="collection-item" style="display:table;width:100%">
 
-							<a href="{% url 'userprofile:profile_by_id' user.user.id %}">
-								{{ user.user.get_full_name }}
-							</a>
+						<a style="height:100%;display:table-cell;overflow:hidden;" href="{% url 'userprofile:profile_by_id' user.user.id %}">
+							{{ user.user.get_full_name }}
+						</a>
 
-							{% if event.is_past_start %}
+						{% if event.is_past_start %}
 
-								{% if user.attended %}
-								<span class="secondary-content tooltipped" data-position="top" data-tooltip="Møtte opp!">
-									😇
-								</span>
-								{% else %}
-								<span class="secondary-content tooltipped" data-position="top" data-tooltip="Ingen oppmøte registrert!">
-									😈
-								</span>
-								{% endif %}
+						<a style="height:100%;display:table-cell;vertical-align:middle;" href="/events/{{ event.id }}/attended">
 
-							{% else %}
-
-							<span class="secondary-content tooltipped" data-position="top" data-tooltip="Venter på arrangementstart">
-								⌛
+							{% if user.attended %}
+							<span class="secondary-content tooltipped" data-position="top" data-tooltip="Oppmøte registrert!">
+								😇
 							</span>
-
+							{% else %}
+							<span class="secondary-content tooltipped" data-position="top" data-tooltip="Ingen oppmøte registrert!">
+								😈
+							</span>
 							{% endif %}
 
-						</li>
+						</a>
+
+						{% else %}
+
+						<span class="secondary-content tooltipped" data-position="top" data-tooltip="Venter på arrangementstart">
+							⌛
+						</span>
+
 						{% endif %}
 
-						{% empty %}
-						<li class="collection-item">Det er ingen påmeldte</li>
+					</li>
+					{% endif %}
+
+					{% empty %}
+					<li class="collection-item">Det er ingen påmeldte</li>
 
 					{% endfor %}
 				</ul>
@@ -78,7 +95,9 @@
 		<div class="row">
 			<div class="col s12 m12">
 				<ul class="collection with-header">
-					<li class="collection-header"><h4>Allergier</h4></li>
+					<li class="collection-header">
+						<h4>Allergier</h4>
+					</li>
 					<li class="collection-item">Foretrekker glutenfritt<span class="badge"> {{ event.get_allergies_registered.gluten }}</span></li>
 					<li class="collection-item">Foretrekker vegetar<span class="badge"> {{ event.get_allergies_registered.vegetar }}</span></li>
 					<li class="collection-item">Foretrekker vegansk<span class="badge"> {{ event.get_allergies_registered.vegan }}</span></li>

--- a/news/templates/news/_event_admin_menu.html
+++ b/news/templates/news/_event_admin_menu.html
@@ -33,12 +33,16 @@
 			<div class="col s12 m12 l6">
 				<ul class="collection with-header">
 					<li class="collection-header">
-						<h4>Alle Påmeldte</h4>
+						<h4>Alle påmeldte</h4>
 					</li>
 					{% for user in event.registration_list %}
 
 						{% if not user.is_waitlisted %}
-						<li class="collection-item">{{ user.user.get_full_name }}
+						<li class="collection-item">
+
+							<a href="{% url 'userprofile:profile_by_id' user.user.id %}">
+								{{ user.user.get_full_name }}
+							</a>
 
 							{% if event.is_past_start %}
 

--- a/news/templates/news/attendee_form.html
+++ b/news/templates/news/attendee_form.html
@@ -39,7 +39,7 @@
 					{% else %}
 					<input type="checkbox" id="attended" name="{{ instance.attended.html_name }}"/>
 					{% endif %}
-					<span>{{ instance.attended.label }}</span>
+					<span>Oppmøtt</span>
 				</label>
 				</div>
 			</div>


### PR DESCRIPTION
- Event attendance list now consists of table-like rows with cell-like items (name and attendance status). This adds better support for long names that break into multiple lines on mobile.
- Attendee names now link to corresponding profile page
- Attendance status icons now link to /attended
- Also made som minor language enhancements in event view and /attended

![Skjermbilde 2020-02-26 kl  20 53 35](https://user-images.githubusercontent.com/24361490/75382119-2e3bb080-58da-11ea-8b79-a6bdcc1ef86b.png)

