### PR TITLE
Removed urlpattern for the old admin panel page

### DIFF
--- a/website/urls.py
+++ b/website/urls.py
@@ -46,7 +46,6 @@ urlpatterns = [
     path('profile/', include('userprofile.urls')),
     path('reservations/', include('reservations.urls')),
     path('members/', ProfileListView.as_view(), name='member-list'),
-    path('admin-panel/', AdminView.as_view(), name='admin'),
     path('feide/', include('social_django.urls', namespace='social')),
     path('api/', include(router.urls)),
 ]


### PR DESCRIPTION
Since the old admin panel page has been replaced, it's natural to remove the associated urlpattern.