### PR TITLE
Added category info page and skill prereq redirects

### DIFF
--- a/userprofile/static/userprofile/css/skills_style.css
+++ b/userprofile/static/userprofile/css/skills_style.css
@@ -12,6 +12,28 @@
     opacity: 0.5;
 }
 
+.skill-category-btn{
+
+  margin-top: 5px;
+
+}
+
+.skill-category-img {
+
+  width: 100%;
+  max-height: 500px;
+  object-fit: cover;
+  border-radius: 2px 2px 0 0;
+}
+
+/* Position skill anchor some distance
+over the actual skill item to compensate
+for the fixed header */
+.skill-anchor{
+  position: relative;
+  top: -200px;
+}
+
 
 /* Tabs styling */
 

--- a/userprofile/static/userprofile/css/userprofile_style.css
+++ b/userprofile/static/userprofile/css/userprofile_style.css
@@ -5,6 +5,17 @@
 
 }
 
+.info-button{
+
+  font-size: 1.5rem;
+  opacity: 0.5;
+
+}
+
+.info-button:hover{
+  opacity: 1;
+}
+
 @media only screen and (min-width: 600px) {
 
   .profile-basic{

--- a/userprofile/static/userprofile/js/display_skill.js
+++ b/userprofile/static/userprofile/js/display_skill.js
@@ -1,0 +1,42 @@
+function displaySkill(id){
+
+  // Iterate both tabs for small and med/large
+  for(tabsDiv of document.querySelectorAll('.tabs')){
+
+    // Tabs controller instance
+    const tabsInstance = M.Tabs.getInstance(tabsDiv);
+
+    // Search through all tab bodies
+    for(const tab of document.querySelectorAll('.tab')){
+
+      const collapsibleDiv = document.querySelector(tab.querySelector('a').getAttribute("href"));
+
+      // Collapsible controller instance
+      const collapsibleInstance = M.Collapsible.getInstance(collapsibleDiv.querySelector('.collapsible'));
+
+      // Collapsible items (represented by their headers)
+      const collapsibleItems = collapsibleDiv.querySelectorAll('.skill-anchor');
+
+      // Search through all tab items
+      for(i = 0;i<collapsibleItems.length;i++){
+
+        // Close this item
+        collapsibleInstance.close(i);
+
+        // Check if user is redirecting to this item
+        if(collapsibleItems[i].id == 'skill' + id){
+
+          // Switch to this tab
+          tabsInstance.select(collapsibleDiv.id);
+
+          // Open item to display skill details
+          collapsibleInstance.open(i);
+
+          // Scroll to item position
+          window.location.hash = collapsibleItems[i].id;
+
+        }
+      }
+    }
+  }
+}

--- a/userprofile/templates/userprofile/profile.html
+++ b/userprofile/templates/userprofile/profile.html
@@ -65,6 +65,9 @@
 							</div>
 							<div class="col category-level-name">
 								<span>{{ category }}</span>
+								<a class="hs-gray-text" href="{% url 'userprofile:profile_skills_category' category.id %}">
+									<i class="material-icons info-button">info</i>
+								</a>
 							</div>
 						</li>
 					{% endfor %}

--- a/userprofile/templates/userprofile/skill_badges.html
+++ b/userprofile/templates/userprofile/skill_badges.html
@@ -1,4 +1,4 @@
-<span class="badge">
+<span class="badge hide-on-small-only">
   {% for category in skill.categories.all %}
     <span class="badge" style="background:{{category.color}}"></span>
   {% endfor %}

--- a/userprofile/templates/userprofile/skill_description.html
+++ b/userprofile/templates/userprofile/skill_description.html
@@ -4,7 +4,7 @@
   <ul class="collection z-depth-0">
     <li class="collection-header"><h6>Forutsetninger</h6></li>
     {% for prereq in skill.prerequisites.all %}
-      <li class="collection-item skill_reachable">
+      <li class="collection-item skill_reachable" onclick="displaySkill({{prereq.id}})">
         {{prereq}}
         {% include "userprofile/skill_badges.html" with skill=prereq %}
       </li>

--- a/userprofile/templates/userprofile/skills.html
+++ b/userprofile/templates/userprofile/skills.html
@@ -3,6 +3,24 @@
 {% block header %}
   <link rel="stylesheet" type="text/css" href="{% static 'userprofile/css/userprofile_style.css' %}">
 	<link rel="stylesheet" type="text/css" href="{% static 'userprofile/css/skills_style.css' %}">
+  <script src="{% static 'userprofile/js/display_skill.js' %}"></script>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        var elems = document.querySelectorAll('.collapsible.expandable');
+        M.Collapsible.init(elems, {
+          accordion: false
+        });
+        M.Tabs.init(document.querySelectorAll('.tabs'));
+    });
+  </script>
+  {% if redirect_skill %}
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+          displaySkill({{redirect_skill.id}})
+      });
+    </script>
+  {% endif %}
 {% endblock %}
 {% block content %}
 <div class="section hs-green white-text">
@@ -32,7 +50,7 @@
           <div class="row">
             {% for category, level in category_levels %}
               <div class="col tooltipped" data-position="bottom" data-tooltip="{{category.name}}">
-                <a class="btn-floating btn btn-flat white-text hs-green" style="background-color:{{category.color}} !important;">
+                <a href="{% url 'userprofile:profile_skills_category' category.id %}" class="btn-floating btn btn-flat white-text hs-green" style="background-color:{{category.color}} !important;">
                   <span>
                     {{ level }}
                   </span>
@@ -52,8 +70,8 @@
           <h4>{{ profile.user.get_full_name }}</h4>
           <div class="row">
             {% for category, level in category_levels %}
-              <div class="col" class="tooltipped" data-position="top" data-tooltip="{{category.name}}">
-                <a class="btn-floating btn btn-flat white-text hs-green" style="background-color:{{category.color}} !important;">
+              <div class="col skill-category-btn" class="tooltipped" data-position="top" data-tooltip="{{category.name}}">
+                <a href="{% url 'userprofile:profile_skills_category' category.id %}" class="btn-floating btn btn-flat white-text hs-green" style="background-color:{{category.color}} !important;">
                   <span>
                     {{ level }}
                   </span>
@@ -69,16 +87,22 @@
       <div class="col s12">
         <div class="row">
           <div class="col s12">
-            <ul class="tabs">
-              <li class="tab col s4"><a class="active" href="#reachable_skills">Neste nivå</a></li>
-              <li class="tab col s4"><a href="#unreachable_skills">Høyere nivåer</a></li>
-              <li class="tab col s4 {% if not profile.skills.all %}disabled{% endif %}"><a href="#acquired_skills">Oppnådde ferdigheter</a></li>
+            <ul class="tabs hide-on-med-and-down">
+              <li id="nextLevelTabSmall" class="tab col s4"><a class="active" href="#reachable_skills">Neste nivå</a></li>
+              <li id="higherLevelsTabSmall" class="tab col s4"><a href="#unreachable_skills">Høyere nivåer</a></li>
+              <li id="acquiredSkillsTabSmall" class="tab col s4 {% if not profile.skills.all %}disabled{% endif %}"><a href="#acquired_skills">Oppnådde ferdigheter</a></li>
+            </ul>
+            <ul class="tabs hide-on-large-only">
+              <li id="nextLevelTab" class="tab col"><a class="active" href="#reachable_skills">Neste</a></li>
+              <li id="higherLevelsTab" class="tab col"><a href="#unreachable_skills">Høyere</a></li>
+              <li id="acquiredSkillsTab" class="tab col {% if not profile.skills.all %}disabled{% endif %}"><a href="#acquired_skills">Oppnådd</a></li>
             </ul>
           </div>
-          <div id="reachable_skills" class="col s12">
+          <div id="reachable_skills" class="tab-body col s12">
             <ul class="collection collapsible expandable z-depth-0">
               {% for skill in reachable_skills %}
                 <li>
+                  <span id="skill{{skill.id}}" class="skill-anchor"></span>
                   <div class="collapsible-header skill-reachable hs-gray white-text">
                     {{skill}}
                     {% include "userprofile/skill_badges.html" %}
@@ -90,11 +114,12 @@
               {% endfor %}
             </ul>
           </div>
-          <div id="unreachable_skills" class="col s12">
+          <div id="unreachable_skills" class="tab-body col s12">
             <ul class="collection collapsible expandable z-depth-0">
               {% for skill in all_skills %}
                 {% if skill not in profile.skills.all and skill not in reachable_skills %}
                   <li>
+                    <span id="skill{{skill.id}}" class="skill-anchor"></span>
                     <div class="collapsible-header skill-unreachable hs-gray white-text">
                       {{skill}}
                       {% include "userprofile/skill_badges.html" %}
@@ -107,11 +132,12 @@
               {% endfor %}
             </ul>
           </div>
-          <div id="acquired_skills" class="col s12">
+          <div id="acquired_skills" class="tab-body col s12">
             {% if profile.skills.all %}
               <ul class="collection collapsible expandable z-depth-0">
                 {% for skill in profile.skills.all %}
                   <li>
+                    <span id="skill{{skill.id}}" class="skill-anchor"></span>
                     <div class="collapsible-header skill-acquired hs-gray white-text">
                       {{skill}}
                       {% include "userprofile/skill_badges.html"%}
@@ -130,16 +156,5 @@
 
   </div>
 </div>
-
-<script>
-
-  document.addEventListener('DOMContentLoaded', function() {
-      var elems = document.querySelectorAll('.collapsible');
-      var instances = M.Collapsible.init(elems, {
-        accordion: false
-      });
-  });
-
-</script>
 
 {% endblock content %}

--- a/userprofile/templates/userprofile/skills_category.html
+++ b/userprofile/templates/userprofile/skills_category.html
@@ -1,0 +1,63 @@
+{% extends "website/base.html" %}
+{% load static %}
+{% block header %}
+  <link rel="stylesheet" type="text/css" href="{% static 'userprofile/css/skills_style.css' %}">
+  <link rel="stylesheet" type="text/css" href="{% static 'news/css/news_style.css' %}">
+
+{% endblock %}
+{% block content %}
+
+<div class="section hs-green">
+	<div class="container">
+    <div class="section no-pad">
+      <img class="responsive-img skill-category-img" src="{{ category.thumb.url }}" />
+    </div>
+		<div class="section card-panel cut-top z-depth-2">
+  		<div class="section container">
+        <div class="row">
+    			<div class="col s12">
+    				<h3 class="center-align hide-on-small-only">{{category}}</h3>
+      			<h5 class="center-align hide-on-med-and-up">{{category}}</h5>
+    			</div>
+    		</div>
+        <div class="row">
+          <div class="col s12">
+            <p class="flow-text">{{category.description}}</p>
+          </div>
+        </div>
+        {% if category_skills %}
+        <div class="row">
+          <div class="col s12">
+    				<h5>Ferdigheter</h5>
+            <ul class="collection collapsible expandable z-depth-0">
+              {% for skill in category_skills %}
+                <li>
+                  <div class="collapsible-header skill-reachable hs-gray white-text">
+                    {{skill}}
+                    {% include "userprofile/skill_badges.html" %}
+                  </div>
+                  <div class="collapsible-body grey lighten-2">
+                    {% include "userprofile/skill_description.html" %}
+                  </div>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+        {% endif %}
+      </div>
+	   </div>
+  </div>
+</div>
+<script>
+
+  document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('.collapsible');
+      var instances = M.Collapsible.init(elems, {
+        accordion: false
+      });
+  });
+
+</script>
+
+{% endblock content %}

--- a/userprofile/urls.py
+++ b/userprofile/urls.py
@@ -10,5 +10,8 @@ urlpatterns = [
     path('<int:pk>/', views.ProfileDetailView.as_view(), name='profile_by_id'),
     path('edit/', views.ProfileUpdateView.as_view(), name="edit_profile"),
     path('skills/', views.SelfSkillsView.as_view(), name="profile_skills"),
-    path('<int:pk>/skills/', views.SkillsView.as_view(), name="profile_skills_by_id")
+    path('skills/<int:skill_pk>', views.SelfSkillsView.as_view(), name="profile_skills"),
+    path('skills/category/<int:pk>', views.SkillsCategoryView.as_view(), name="profile_skills_category"),
+    path('<int:pk>/skills/', views.SkillsView.as_view(), name="profile_skills_by_id"),
+    path('<int:pk>/skills/<int:skill_pk>', views.SkillsView.as_view(), name="profile_skills_by_id")
 ]

--- a/userprofile/views.py
+++ b/userprofile/views.py
@@ -132,6 +132,11 @@ class SkillsView(DetailView, CategoryLevelsMixin):
         context['all_skills'] = Skill.objects.all()
         context['reachable_skills'] = self.get_reachable_skills()
         context['category_levels'] = self.get_category_levels()
+        try:
+            context['redirect_skill'] = Skill.objects.get(id=self.kwargs['skill_pk'])
+        except:
+            pass
+            
         return context
 
     def get_object(self):
@@ -149,6 +154,17 @@ class SelfSkillsView(SkillsView):
             return userprofile
         except AttributeError:
             raise Http404("Profile not found")
+
+class SkillsCategoryView(DetailView):
+
+    model = Category
+    template_name = "userprofile/skills_category.html"
+
+    def get_context_data(self, **kwargs):
+
+        context = super().get_context_data(**kwargs)
+        context['category_skills'] = Skill.objects.filter(categories__pk = self.object.pk)
+        return context
 
 
 class TermsOfServiceView(DetailView):


### PR DESCRIPTION
- Category info page displays information about a category (name and description) and a list of related skills.
- Prerequisites are now clickable on the `/skills` page. When clicked, the related skill is revealed inside the tabs and collapsible system.