### PR TITLE
Improved linking to skills and moved inline scripts

### DIFF
--- a/userprofile/static/userprofile/javascript/display_skill.js
+++ b/userprofile/static/userprofile/javascript/display_skill.js
@@ -1,3 +1,22 @@
+document.addEventListener('DOMContentLoaded', function() {
+
+    // Initalize collapsibles (one per skill)
+    var collapsibles = document.querySelectorAll('.collapsible.expandable');
+    M.Collapsible.init(collapsibles, {
+      accordion: false
+    });
+
+    // Initalize tabs (for skill categories: reachable, unreachable, acquired)
+    M.Tabs.init(document.querySelectorAll('.tabs'));
+
+    // Retrieve redirect skill id from custom attribute in script tag
+    const id = document.getElementById("display_skill").getAttribute('data-redirect-to');
+    if(id){
+      displaySkill(id);
+    }
+
+});
+
 function displaySkill(id){
 
   // Iterate both tabs for small and med/large
@@ -11,8 +30,14 @@ function displaySkill(id){
 
       const collapsibleDiv = document.querySelector(tab.querySelector('a').getAttribute("href"));
 
+      const collapsible = collapsibleDiv.querySelector('.collapsible');
+
+      if(!collapsible){
+        continue;
+      }
+
       // Collapsible controller instance
-      const collapsibleInstance = M.Collapsible.getInstance(collapsibleDiv.querySelector('.collapsible'));
+      const collapsibleInstance = M.Collapsible.getInstance(collapsible);
 
       // Collapsible items (represented by their headers)
       const collapsibleItems = collapsibleDiv.querySelectorAll('.skill-anchor');
@@ -33,7 +58,10 @@ function displaySkill(id){
           collapsibleInstance.open(i);
 
           // Scroll to item position
-          window.location.hash = collapsibleItems[i].id;
+          document.getElementById(collapsibleItems[i].id).scrollIntoView();
+
+          // Update url skill id
+          window.history.replaceState(null, '', id);
 
         }
       }

--- a/userprofile/templates/userprofile/skills.html
+++ b/userprofile/templates/userprofile/skills.html
@@ -5,24 +5,7 @@
 	<link rel="stylesheet" type="text/css" href="{% static 'userprofile/css/skills_style.css' %}">
   <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
   <script src="{% static 'userprofile/javascript/approve_skill.js' %}"></script>
-  <script src="{% static 'userprofile/javascript/display_skill.js' %}"></script>
-
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        var elems = document.querySelectorAll('.collapsible.expandable');
-        M.Collapsible.init(elems, {
-          accordion: false
-        });
-        M.Tabs.init(document.querySelectorAll('.tabs'));
-    });
-  </script>
-  {% if redirect_skill %}
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-          displaySkill({{redirect_skill.id}})
-      });
-    </script>
-  {% endif %}
+  <script id="display_skill" src="{% static 'userprofile/javascript/display_skill.js' %}" data-redirect-to={{redirect_skill.id}}></script>
 {% endblock %}
 {% block content %}
 <div class="section hs-green white-text">


### PR DESCRIPTION
- Skills on profile page can now be linked to with url (`../profile/<profile_id>/skills/<skill_id>`)

  - Clicking through skills ignores browser history (back button will go to last page, not last clicked skill)

- Moved some inline scripts related to skill displaying into a related script file
- Fixed a bug relating to empty tabs