### PR TITLE
Footer improvements

### DIFF
--- a/website/templates/website/footer.html
+++ b/website/templates/website/footer.html
@@ -56,8 +56,8 @@
 		<div class="container white-text">
 			<div class="row">
 				<div class="col s12">
-					<a href="https://www.ntnu.no/idi/" target="_blank"><img style="width: 300px;" src="{% static 'website/img/logo/IDI_logo_white.svg' %}"></a>
-					<a href="https://www.ntnu.no/ie/kid/" target="_blank"><img style="width: 300px;" src="{% static 'website/img/logo/KiD_logo_white.png' %}"></a>
+					<a href="https://www.ntnu.no/idi/" target="_blank"><img style="width: 100%; max-width: 300px;" src="{% static 'website/img/logo/IDI_logo_white.svg' %}"></a>
+					<a href="https://www.ntnu.no/ie/kid/" target="_blank"><img style="width: 100%; max-width: 300px;" src="{% static 'website/img/logo/KiD_logo_white.png' %}"></a>
 				</div>
 			</div>
 			<p>© {% now "Y" %} Hackerspace NTNU</p>

--- a/website/templates/website/footer.html
+++ b/website/templates/website/footer.html
@@ -14,7 +14,7 @@
 					</p>
 					<p class="col s6">
 						Åpningstider:<br>
-						10.15 - 18.00<br>
+						10:15 - 18:00<br>
 						Alle hverdager
 					</p>
 				</div>
@@ -41,8 +41,11 @@
 							{% else %}
 							<li><a href="{% url 'social:begin' 'dataporten_feide' %}?next={{ request.path }}">Logg inn</a></li>
 							{% endif %}
-				<p>Har du funnet en <i class="material-icons">bug_report</i>?
-					<br>Send gjerne en <a href="mailto:hackerspace-dev@idi.ntnu.no">mail</a> til DevOps eller bruk #dev-public kanalen på Slack!</p>
+							<p>
+								Har du funnet en <i class="material-icons">bug_report</i>?<br>
+								Send gjerne en <a href="mailto:hackerspace-dev@idi.ntnu.no">mail</a> til DevOps eller bruk #dev-public kanalen på Slack!
+								Du kan også rapportere feil eller gi oss forslag til forbedringer på <a href="https://github.com/hackerspace-ntnu/website/issues/new/choose">GitHub</a>.
+							</p>
 						</ul>
 					</div>
 				</div>

--- a/website/templates/website/footer.html
+++ b/website/templates/website/footer.html
@@ -6,10 +6,18 @@
 				<h5>Hackerspace</h5>
 				<div class="divider"></div>
 				<p>Velkommen innom <a target="_blank" href="http://bit.ly/2RXBJMd">verkstedet</a> på NTNU Gløshaugen for en kopp kaffe!</p>
-				<p> Realfagsbygget, A-Blokka<br>
-					Høgskoleringen 5<br>
-					7034 Trondheim
-				</p>
+				<div class="row">
+					<p class="col s6">
+						Realfagsbygget, A-Blokka<br>
+						Høgskoleringen 5<br>
+						7034 Trondheim
+					</p>
+					<p class="col s6">
+						Åpningstider:<br>
+						10.15 - 18.00<br>
+						Alle hverdager
+					</p>
+				</div>
 				<p>For øvrige henvendelser kan du også ta kontakt via <a class="white-text" href="mailto:hackerspace-styret@idi.ntnu.no">hackerspace-styret@idi.ntnu.no</a>
 			</div>
 			<div class="col m6 l4 hide-on-small-only">


### PR DESCRIPTION
Including opening hours for the workshop and a link to our issue tracker. The GitHub link leads to the [issue format picker](https://github.com/hackerspace-ntnu/website/issues/new/choose). Also fixes cutoff on the NTNU IDI and KID logos on *extremely* small displays.

Closes #500 

![bilde](https://user-images.githubusercontent.com/9088854/96456553-eaa60600-121e-11eb-99fd-218714d78312.png)

![bilde](https://user-images.githubusercontent.com/9088854/96457291-df070f00-121f-11eb-833f-68035d3c7a70.png)
