### PR TITLE
Oppdatert tekst på /members

### DIFF
--- a/userprofile/templates/userprofile/profile_list.html
+++ b/userprofile/templates/userprofile/profile_list.html
@@ -6,7 +6,7 @@
 		<div class="row">
 			<div class="col s12">
 				<h4 class="white-text">Medlemmer i Hackerspace</h4>
-				<p class="flow-text white-text">For å se enkel oversikt gruppers medlemmer, sjekk ut <a class="hs-gray-text" href="{% url 'about' %}"> om oss</a> siden.</p>
+				<p class="flow-text white-text">For oversikt over gruppene og deres medlemmer, se <a class="hs-gray-text" href="{% url 'about' %}"> Om oss</a>.</p>
 			</div>
 		</div>
 		<div class="row">


### PR DESCRIPTION
Endret fra:
For å se enkel oversikt gruppers medlemmer, sjekk ut om oss siden.

Til:
For oversikt over gruppene og deres medlemmer, se Om oss