### PR TITLE
Add more permanent MazeMap link

### DIFF
--- a/inventory/templates/inventory/inventory.html
+++ b/inventory/templates/inventory/inventory.html
@@ -5,7 +5,7 @@
 <div class="section hs-yellow">
     <div class="container center">
         <p>Lagersystemet er nytt, og vi jobber med å føre inn alt vi har på verkstedet. Derfor kan det hende at enkelte ting ikke er oppført.</p>
-        <p>Hvis du lurer på om vi har spesifikt utstyr eller ønsker å låne noe som ikke ligger i lagersystemet kan du komme innom <a class="white-text" href="http://bit.ly/2RXBJMd">verkstedet</a> og spørre om vi har det likevel!</p>
+        <p>Hvis du lurer på om vi har spesifikt utstyr eller ønsker å låne noe som ikke ligger i lagersystemet kan du komme innom <a class="white-text" target="_blank" href="{{ mazemap_link }}">verkstedet</a> og spørre om vi har det likevel!</p>
     </div>
 </div>
 
@@ -104,7 +104,7 @@
         <div class="row center">
             <div class="col s12">
                 <h3>Fant ingenting på lageret <i class="material-icons medium">sentiment_dissatisfied</i></h3>
-                <p>Det kan likevel hende at vi har det du leter etter. Kom innom <a href="http://bit.ly/2RXBJMd">verkstedet</a> og spør oss!</p>
+                <p>Det kan likevel hende at vi har det du leter etter. Kom innom <a target="_blank" href="{{ mazemap_link }}">verkstedet</a> og spør oss!</p>
             </div>
         </div>
         {% endif %}

--- a/website/context_processors.py
+++ b/website/context_processors.py
@@ -1,0 +1,3 @@
+def common_info(request):
+    return {
+    }

--- a/website/context_processors.py
+++ b/website/context_processors.py
@@ -1,3 +1,4 @@
 def common_info(request):
     return {
+        'mazemap_link': "https://use.mazemap.com/?v=1&campusid=1&sharepoitype=identifier&sharepoi=360-A2-116",
     }

--- a/website/settings.py
+++ b/website/settings.py
@@ -119,6 +119,8 @@ TEMPLATES = [
                 "social_django.context_processors.backends",
                 "social_django.context_processors.login_redirect",
                 #"sekizai.context_processors.sekizai",
+
+                "website.context_processors.common_info",
             ],
             'debug': DEBUG,
         }

--- a/website/templates/website/about.html
+++ b/website/templates/website/about.html
@@ -21,7 +21,7 @@
 				<p class="flow-text">Hackerspace NTNU er et studentdrevet prosjekt åpent for alle studenter uansett studieretning eller Hackerspace-medlemsskap. Vi tilbyr en kreativ arena der studenter fra forskjellige linjer kan få hjelp til å realisere idéene sine i et engasjert og inkluderende miljø. Hos oss finner du ny teknologi til din disposisjon, blant annet droner, 3D-printere og Virtual Reality-utstyr.</p>
 				<p class="flow-text">Om du er en førsteklassing som trenger hjelp med ditt første Arduino-prosjekt eller en fjerdeklassing som ønsker å lage en 3D-modell av Trondheim, kan vi stille med både utstyr og kompetanse. Vi holder også regelmessig kurs for både nybegynnere og viderekomne innen mange spennende emner.</p>
 				<p class="flow-text">Kom innom for å se hva vi driver med og slå av en prat. <br>Du finner oss i andre etasje i A-Blokka på Realfagsbygget NTNU Gløshaugen.</p>
-				<a class="btn btn-flat btn-large waves-effect waves-light hs-green white-text" target="_blank" href="http://bit.ly/2RXBJMd"><i class="material-icons small">map</i> Vis kart</a>
+				<a class="btn btn-flat btn-large waves-effect waves-light hs-green white-text" target="_blank" href="{{ mazemap_link }}"><i class="material-icons small">map</i> Vis kart</a>
 			</div>
 		</div>
 	</div>

--- a/website/templates/website/about.html
+++ b/website/templates/website/about.html
@@ -20,7 +20,7 @@
 				<h4>Hva er Hackerspace?</h4>
 				<p class="flow-text">Hackerspace NTNU er et studentdrevet prosjekt åpent for alle studenter uansett studieretning eller Hackerspace-medlemsskap. Vi tilbyr en kreativ arena der studenter fra forskjellige linjer kan få hjelp til å realisere idéene sine i et engasjert og inkluderende miljø. Hos oss finner du ny teknologi til din disposisjon, blant annet droner, 3D-printere og Virtual Reality-utstyr.</p>
 				<p class="flow-text">Om du er en førsteklassing som trenger hjelp med ditt første Arduino-prosjekt eller en fjerdeklassing som ønsker å lage en 3D-modell av Trondheim, kan vi stille med både utstyr og kompetanse. Vi holder også regelmessig kurs for både nybegynnere og viderekomne innen mange spennende emner.</p>
-				<p class="flow-text">Kom innom for å se hva vi driver med og slå av en prat. <br>Du finner oss i andre etasje i A-Blokka på Realfagsbygget NTNU Gløshaugen.</p>
+				<p class="flow-text">Kom innom for å se hva vi driver med og slå av en prat. <br>Du finner oss i andre etasje i A-blokka på Realfagbygget, NTNU Gløshaugen.</p>
 				<a class="btn btn-flat btn-large waves-effect waves-light hs-green white-text" target="_blank" href="{{ mazemap_link }}"><i class="material-icons small">map</i> Vis kart</a>
 			</div>
 		</div>

--- a/website/templates/website/footer.html
+++ b/website/templates/website/footer.html
@@ -8,7 +8,7 @@
 				<p>Velkommen innom <a target="_blank" href="{{ mazemap_link }}">verkstedet</a> på NTNU Gløshaugen for en kopp kaffe!</p>
 				<div class="row">
 					<p class="col s6">
-						Realfagsbygget, A-Blokka<br>
+						Realfagbygget, A-blokka<br>
 						Høgskoleringen 5<br>
 						7034 Trondheim
 					</p>

--- a/website/templates/website/footer.html
+++ b/website/templates/website/footer.html
@@ -5,7 +5,7 @@
 			<div class="col s12 m12 l4">
 				<h5>Hackerspace</h5>
 				<div class="divider"></div>
-				<p>Velkommen innom <a target="_blank" href="http://bit.ly/2RXBJMd">verkstedet</a> på NTNU Gløshaugen for en kopp kaffe!</p>
+				<p>Velkommen innom <a target="_blank" href="{{ mazemap_link }}">verkstedet</a> på NTNU Gløshaugen for en kopp kaffe!</p>
 				<div class="row">
 					<p class="col s6">
 						Realfagsbygget, A-Blokka<br>

--- a/website/templates/website/header.html
+++ b/website/templates/website/header.html
@@ -87,7 +87,7 @@
 					<!-- Dropdown for resurser -->
 					<ul id="resourcedropdown" class="dropdown-content">
 						<li class="tooltipped" data-position="left" data-tooltip="Se hvor vi befinner oss">
-							<a class="modal-trigger waves-effect hs-green-text" target="_blank" href="http://bit.ly/2RXBJMd">Kart</a>
+							<a class="modal-trigger waves-effect hs-green-text" target="_blank" href="{{ mazemap_link }}">Kart</a>
 						</li>
 						<li class="tooltipped" data-position="left" data-tooltip="Se liste over medlemmer">
 							<a href="{% url 'member-list' %}">Medlemmer</a>

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -50,7 +50,7 @@
 				<h4>Hvem er vi?</h4>
 				<p>Hackerspace NTNU er et studentdrevet prosjekt åpent for alle studenter uavhengig av studieretning.</p>
 				<p>Hos oss finner du ny teknologi til din disposisjon, blant annet droner, 3D-printere og Virtual Reality-utstyr.</p><p>Enten du ønsker å få en LED-lampe til å blinke eller lage en 3D-modell av Trondheim, kan medlemmene i Hackerspace tilby variert og god kompetanse og hjelpe deg med det, uavhengig av ditt medlemsskap i Hackerspace.</p>
-				<p>Om du lurer på noe, har et prosjekt du ønsker hjelp med, eller bare vil slå av en prat, tar vi deg varmt imot på <a class="hs-green-text" target="_blank" href="http://bit.ly/2RXBJMd">vårt verksted</a> og <a class="hs-green-text" target="_blank" href="https://hackerspace-ntnu.slack.com/">Slack-kanal</a>.</p>
+				<p>Om du lurer på noe, har et prosjekt du ønsker hjelp med, eller bare vil slå av en prat, tar vi deg varmt imot på <a class="hs-green-text" target="_blank" href="{{ mazemap_link }}">vårt verksted</a> og <a class="hs-green-text" target="_blank" href="https://hackerspace-ntnu.slack.com/">Slack-kanal</a>.</p>
 				<p>Vaktordningen sørger for at du alltid møter noen på verkstedet klare til å demonstrere utstyr eller hjelpe deg.</p>
 				<a class="btn-flat btn-med waves-effect hs-green white-text" href="/about/">Les mer om oss her</a>
 			</div>


### PR DESCRIPTION
The [`360-A2-116`](https://use.mazemap.com/?v=1&campusid=1&sharepoitype=identifier&sharepoi=360-A2-116) ID should be more long-lived than the [`6379`](https://use.mazemap.com/#v=1&zlevel=2&center=10.404406,63.415418&zoom=18&sharepoitype=poi&sharepoi=6379&campuses=ntnu&campusid=1&utm_medium=url_scheme) POI ID that the "bit.ly" link points to, according to a support employee in MazeMap, who I contacted.

Also extracted the references to the link to a template context processor, which makes it easier to update the link in the future.