### PR TITLE
Add `pull_request` trigger to integration

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,6 @@
 name: Python Integration
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Integration test would not always run when recieving external pull requests. attempts to fix that.