### PR TITLE
Excluded drafts from prev/next articles and internal count

### DIFF
--- a/news/views.py
+++ b/news/views.py
@@ -174,7 +174,7 @@ class ArticleView(DetailView):
         can_access_internal_article = self.request.user.has_perm('news.can_view_internal_article')
 
         # Get permitted articles
-        article_list = Article.objects.filter(internal__lte=can_access_internal_article)
+        article_list = Article.objects.filter(internal__lte=can_access_internal_article,draft=False)
 
         # Get oldest article that is newer than current (None if current is latest)
         next_article = article_list.filter(pub_date__gt=self.get_object().pub_date).order_by('pub_date').first()

--- a/news/views.py
+++ b/news/views.py
@@ -110,9 +110,7 @@ class ArticleListView(ListView):
 
     def get_internal_articles_indicator(self):
 
-        # Determine number of hidden internal articles
         if not self.request.user.has_perm('news.can_view_internal_article'):
-            internal_articles_count = len(Article.objects.filter(internal=True))
             return "Du har ikke rettigheter til å se interne artikler."
 
         return None

--- a/website/views.py
+++ b/website/views.py
@@ -85,7 +85,7 @@ class IndexView(TemplateView):
 
         # Determine number of hidden internal articles
         if not self.request.user.has_perm('news.can_view_internal_article'):
-            internal_articles_count = len(Article.objects.filter(internal=True))
+            internal_articles_count = len(Article.objects.filter(internal=True,draft=False))
         else:
             internal_articles_count = 0
 
@@ -152,7 +152,8 @@ class IndexView(TemplateView):
 
         # Get five published articles
         article_list = Article.objects.filter(
-            internal__lte=can_access_internal_article).filter(draft=False).order_by('-pub_date')[:5]
+            internal__lte=can_access_internal_article,draft=False
+        ).order_by('-pub_date')[:5]
 
         # Få dørstatus
         try:


### PR DESCRIPTION
Draft articles where visible as previous/next articles, as well as counted towards the internal articles count. They are now excluded from this.

(Also neutralized a useless variable 🤺)