### PR TITLE
Replaced discontinued shim from social-auth-app-django

### DIFF
--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -6,7 +6,7 @@ from social_django.models import UserSocialAuth
 from django.contrib.auth import get_user_model
 
 from django.conf import settings
-from social_django.compat import reverse
+from django.urls import reverse
 from authentication.views import associate_by_email, save_profile
 from social_django.utils import load_strategy, load_backend
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ django-filter
 markdown
 pillow
 python-dataporten-auth
-python-social-auth[django]
+social-auth-app-django==5.0.0


### PR DESCRIPTION
The 5.0.0 release of `social-auth-app-django` introduced [a breaking change](https://github.com/python-social-auth/social-app-django/pull/263) ([permalink](https://web.archive.org/web/20210831080835/https://github.com/python-social-auth/social-app-django/pull/263)) that removed a utility function used in one of our auth tests.

This has now been updated in line with the 5.0.0 change.

The requirement in question has also been updated with a fixed version number to possibly avoid future breaking changes from this package.