### PR TITLE
Fix/calendar name and phone undefined

### DIFF
--- a/reservations/templates/reservations/queue_detail.html
+++ b/reservations/templates/reservations/queue_detail.html
@@ -199,15 +199,17 @@
 				textColor: '#FFF',
 			},
 			eventRender: function(info) {
-				var elem = info.el
-				elem.setAttribute("style", 'font-size: 1rem;');
+				const elem = info.el
+				let elemStyle = "white-space: pre-line;";
 				// Add event owner and comment as tooltip for members
 				if (requestUser == info.event.extendedProps.user) {
-					elem.setAttribute("style", "background-color: #5BBA47;");
+					elemStyle += "background-color: #5BBA47;";
 					M.Tooltip.init(info.el, {html: "Trykk for å redigere" });
 				} else {
-					elem.setAttribute("style", "background-color: #4E4B46;");
+					elemStyle += "background-color: #4E4B46;";
 				}
+				elem.setAttribute("style", elemStyle);
+
 				{% if perms.reservations.view_user_details %}
 				{# kun dersom en bruker har rettigheter til å se navn og nummer #}
 					elem.append((info.event.extendedProps.fullname ?? "") + "\n");

--- a/reservations/templates/reservations/queue_detail.html
+++ b/reservations/templates/reservations/queue_detail.html
@@ -200,7 +200,7 @@
 			},
 			eventRender: function(info) {
 				const elem = info.el
-				let elemStyle = "white-space: pre-line;";
+				let elemStyle = "white-space: pre-line; overflow-wrap: break-word;";
 				// Add event owner and comment as tooltip for members
 				if (requestUser == info.event.extendedProps.user) {
 					elemStyle += "background-color: #5BBA47;";

--- a/reservations/templates/reservations/queue_detail.html
+++ b/reservations/templates/reservations/queue_detail.html
@@ -210,9 +210,9 @@
 				}
 				{% if perms.reservations.view_user_details %}
 				{# kun dersom en bruker har rettigheter til å se navn og nummer #}
-					elem.append(info.event.extendedProps.fullname + "\n");
+					elem.append((info.event.extendedProps.fullname ?? "") + "\n");
 
-					elem.append(info.event.extendedProps.phone);
+					elem.append(info.event.extendedProps.phone ?? "");
 				{% endif %}
 			}
 		});

--- a/reservations/templates/reservations/queue_detail.html
+++ b/reservations/templates/reservations/queue_detail.html
@@ -212,9 +212,9 @@
 
 				{% if perms.reservations.view_user_details %}
 				{# kun dersom en bruker har rettigheter til å se navn og nummer #}
-					elem.append((info.event.extendedProps.fullname ?? "") + "\n");
+					elem.append((info.event.extendedProps.user ? info.event.extendedProps.fullname : "{{ request.user.get_full_name }}"), "\n");
 
-					elem.append(info.event.extendedProps.phone ?? "");
+					elem.append(info.event.extendedProps.user ? info.event.extendedProps.phone : "{{ request.user.profile.phone_number }}");
 				{% endif %}
 			}
 		});


### PR DESCRIPTION
Make the timeslot text show the users name and phone number instead of 'undefined undefined' while selecting time
This also makes the name and phone number actually go on separate lines