### PR TITLE
Include group choice priorities in application confirmation email

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -46,9 +46,13 @@ class ApplicationForm(ModelForm):
             choice.save()
 
     def send_email(self):
+
+        # Retrieve group choice with priorities (assumes that save() has been run first)
+        group_choice = ApplicationGroupChoice.objects.filter(application=self.instance.id).order_by("priority")
+
         plain_message = render_to_string('applications/application_success_mail.txt', {
-            'navn': self.cleaned_data['name'],
-            'grupper': self.cleaned_data['group_choice']
+            'name': self.cleaned_data['name'],
+            'group_choice': group_choice
         })
 
         send_mail(

--- a/applications/templates/applications/application_success_mail.txt
+++ b/applications/templates/applications/application_success_mail.txt
@@ -1,10 +1,10 @@
-Hei {{ navn }}!
+Hei {{ name }}!
 
 Dette er en bekreftelse på at din søknad er registrert.
 
 Du har søkt følgende grupper:
-{% for group in grupper %}
-- {{ group }}
+{% for choice in group_choice %}
+{{ choice.priority }}. {{ choice.group }}
 {% endfor %}
 
 Vi svarer på søknader fortløpende etter søknadsfristen går ut.

--- a/applications/tests.py
+++ b/applications/tests.py
@@ -79,3 +79,30 @@ class ApplicationFormViewTest(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, '[Hackerspace NTNU] Søknad er registrert!')
         self.assertEqual(mail.outbox[0].to[0], data.get('email'))
+        self.assertEqual(
+            mail.outbox[0].body,
+            """Hei Testesson Test!
+
+Dette er en bekreftelse på at din søknad er registrert.
+
+Du har søkt følgende grupper:
+
+1. DevOps
+
+2. LabOps
+
+
+Vi svarer på søknader fortløpende etter søknadsfristen går ut.
+Denne mailen kan ikke besvares.
+
+Dersom du skulle ha noen spørsmål vedrørende din søknad, ta kontakt med
+hackerspace-styret@idi.ntnu.no
+
+
+Tusen takk for din interesse. :-)
+
+
+Mvh,
+Styret i Hackerspace NTNU
+"""
+        )

--- a/applications/views.py
+++ b/applications/views.py
@@ -22,8 +22,8 @@ class ApplicationView(FormView):
     success_url = '/opptak/success'
 
     def form_valid(self, form):
+        form.save()  # must save before sending email in order to access group choice priorities
         form.send_email()
-        form.save()
         return super(ApplicationView, self).form_valid(form)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Fixes #567 

Group choice priorities are now included in the application confirmation email. 