### PR TITLE
Add search to user select on admin site

### DIFF
--- a/committees/admin.py
+++ b/committees/admin.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
 
-# Register your models here.
 from .models import Committee
 
-admin.site.register(Committee)
 
+class CommitteeAdmin(admin.ModelAdmin):
+    autocomplete_fields = ['main_lead', 'second_lead', 'economy']
+
+
+admin.site.register(Committee, CommitteeAdmin)

--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from .models import Item, ItemLoan
 
+
 @admin.register(Item)
 class ItemAdmin(admin.ModelAdmin):
     fieldsets = [
@@ -22,4 +23,9 @@ class ItemAdmin(admin.ModelAdmin):
         'name',
     ]
 
-admin.site.register(ItemLoan)
+
+class ItemLoanAdmin(admin.ModelAdmin):
+    autocomplete_fields = ['approver']
+
+
+admin.site.register(ItemLoan, ItemLoanAdmin)

--- a/reservations/admin.py
+++ b/reservations/admin.py
@@ -7,6 +7,7 @@ from reservations.models import Queue, Reservation
 class ReservationAdmin(ModelAdmin):
     model = Reservation
     ordering = ('-start', '-end')
+    autocomplete_fields = ['user']
 
 
 admin.site.register(Queue)

--- a/website/models.py
+++ b/website/models.py
@@ -3,6 +3,11 @@ from django.db import models
 from files.models import Image
 from datetime import datetime
 
+from django.contrib.auth.models import User
+
+# Set custom User string representation
+User.add_to_class("__str__", lambda u: f"{u.get_full_name()} ({u.username})")
+
 
 class Card(models.Model):
     title = models.CharField(max_length=100, verbose_name='Title', blank=False)


### PR DESCRIPTION
Solves #571 

Adds search functionality to the standard select widget for user fields on the admin sites Committees, ItemLoans and Reservations. Utilizes the `autocomplete_fields` property.