### PR TITLE
Fix reservations validation and fullcalendar

### DIFF
--- a/reservations/serializers.py
+++ b/reservations/serializers.py
@@ -50,10 +50,10 @@ class ReservationsSerializer(serializers.ModelSerializer):
 
         # disallow weekend and late/early hour reservations to non-members
         user = self.context['request'].user
-        if not user.has_perm('reservations.add_reservation') and not user.is_superuser:
+        if not user.has_perm('reservations.view_user_details') and not user.is_superuser:
             if attrs['start'].time().hour < 10 or attrs['end'].time().hour > 18 \
-                    or attrs['start'].date().weekday() >= 6 or attrs['end'].date().weekday() >= 6 \
-                    or attrs['start'].date() != attrs['end'].date():
+                or attrs['start'].date().weekday() >= 6 or attrs['end'].date().weekday() >= 6 \
+                or attrs['start'].date() != attrs['end'].date():
                 raise serializers.ValidationError(
                     "Non-members are not allowed to make reservations outside opening hours"
                 )

--- a/reservations/serializers.py
+++ b/reservations/serializers.py
@@ -28,6 +28,7 @@ class PrivacyCharField(serializers.CharField):
 
 
 class ReservationsSerializer(serializers.ModelSerializer):
+    user = serializers.ReadOnlyField(source="user.id")
     fullname = serializers.ReadOnlyField(source="user.get_full_name")
     phone = serializers.ReadOnlyField(source="user.profile.phone_number")
 
@@ -72,5 +73,8 @@ class ReservationsSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError('Valgt slutttid overlapper med annen reservasjon.')
             elif (attrs['start'] <= r.start) and (attrs['end'] >= r.end):
                 raise serializers.ValidationError('Valgt start og slutttid overlapper med annen reservasjon.')
+
+        # Specify the reservee here instead of in the request (to prevent someone from reserving for someone else...)
+        attrs['user'] = self.context['request'].user
 
         return attrs

--- a/reservations/serializers.py
+++ b/reservations/serializers.py
@@ -27,15 +27,6 @@ class PrivacyCharField(serializers.CharField):
         return None
 
 
-class RestrictedReservationSerializer(serializers.ModelSerializer):
-    user = PrivacyUserField(queryset=User.objects.all())
-    comment = PrivacyCharField(required=False, allow_blank=True)
-
-    class Meta:
-        model = Reservation
-        fields = ('start', 'end', 'user', 'parent_queue', 'comment', 'id')
-
-
 class ReservationsSerializer(serializers.ModelSerializer):
     fullname = serializers.ReadOnlyField(source="user.get_full_name")
     phone = serializers.ReadOnlyField(source="user.profile.phone_number")

--- a/reservations/templates/reservations/queue_detail.html
+++ b/reservations/templates/reservations/queue_detail.html
@@ -79,7 +79,7 @@
 
 {% include 'reservations/reservation_modal.html' %}
 <script>
-	const requestUser = '{{ request.user.id }}';
+	const requestUser = {{ request.user.id }};
 	const pk = '{{ object.id }}';
 
 	let newStartField = document.getElementById('id_start');
@@ -138,9 +138,8 @@
 			weekends: false,
 			{% endif %}
 			eventClick: function(eventClickInfo) {
-				console.log(eventClickInfo);
-				{% if not request.user.is_superuser %}
-				if (requestUser == eventClickInfo.event.extendedProps.user) {
+				const isSuperuser = {% if request.user.is_superuser %} true {% else %} false {% endif %};
+				if (requestUser === eventClickInfo.event.extendedProps.user || isSuperuser) {
 					let modal = document.getElementById("updateModal");
 					exStartField.value = DateTimeFormat(eventClickInfo.event.start);
 					exEndField.value = DateTimeFormat(eventClickInfo.event.end);
@@ -150,16 +149,6 @@
 					instance.open();
 					M.updateTextFields();
 				}
-				{% else %}
-					let modal = document.getElementById("updateModal");
-					exStartField.value = DateTimeFormat(eventClickInfo.event.start);
-					exEndField.value = DateTimeFormat(eventClickInfo.end);
-					exCommentField.value = eventClickInfo.event.extendedProps.comment;
-					exIdField.value = eventClickInfo.event.id;
-					let instance = M.Modal.getInstance(modal);
-					instance.open();
-					M.updateTextFields();
-				{% endif %}
 			},
 			select: function (selectionInfo) {
 				{% if request.user.is_authenticated %}

--- a/reservations/templates/reservations/queue_detail.html
+++ b/reservations/templates/reservations/queue_detail.html
@@ -81,6 +81,8 @@
 <script>
 	const requestUser = {{ request.user.id }};
 	const pk = '{{ object.id }}';
+    const isSuperuser = {{ request.user.is_superuser|yesno:"true,false" }};
+    const isMember = {{ perms.reservations.view_user_details|yesno:"true,false" }};
 
 	let newStartField = document.getElementById('id_start');
 	let newEndField = document.getElementById('id_end');
@@ -130,17 +132,10 @@
 				omitZeroMinute: false,
 			},
 			selectOverlap: false,
-			{% if perms.reservations.view_user_details %}
-			minTime: "00:00:00",
-			maxTime: "23:59:59",
-			weekends: true,
-			{% else %}
-			minTime: "10:00:00",
-			maxTime: "18:00:00",
-			weekends: false,
-			{% endif %}
+			minTime: isMember ? "00:00:00" : "10:00:00",
+			maxTime: isMember ? "23:59:59" : "18:00:00",
+			weekends: isMember,
 			eventClick: function(eventClickInfo) {
-				const isSuperuser = {% if request.user.is_superuser %} true {% else %} false {% endif %};
 				if (requestUser === eventClickInfo.event.extendedProps.user || isSuperuser) {
 					let modal = document.getElementById("updateModal");
 					exStartField.value = DateTimeFormat(eventClickInfo.event.start);
@@ -154,35 +149,31 @@
 			},
 			select: function (selectionInfo) {
 				{% if request.user.is_authenticated %}
-				{% if not request.user.profile.phone_number %}
-				{# Hvis bruker ikke har lagt inn telefonnummer #}
-				let modal = document.getElementById("phoneNumberModal");
-				let instance = M.Modal.getInstance(modal);
-				instance.open();
-				M.updateTextFields();
+                    {% if not request.user.profile.phone_number %}
+                        {# Hvis bruker ikke har lagt inn telefonnummer #}
+                        let modal = document.getElementById("phoneNumberModal");
+                        let instance = M.Modal.getInstance(modal);
+                        instance.open();
+                        M.updateTextFields();
+                    {% else %}
+                        let modal = document.getElementById("reservationModal");
+                        newStartField.value = DateTimeFormat(selectionInfo.start);
+                        newEndField.value = DateTimeFormat(selectionInfo.end);
+                        newCommentField.value = "";
+                        let instance = M.Modal.getInstance(modal);
+                        instance.open();
+                        M.updateTextFields();
+                    {% endif %}
 				{% else %}
-				let modal = document.getElementById("reservationModal");
-				newStartField.value = DateTimeFormat(selectionInfo.start);
-				newEndField.value = DateTimeFormat(selectionInfo.end);
-				newCommentField.value = "";
-				let instance = M.Modal.getInstance(modal);
-				instance.open();
-				M.updateTextFields();
-				{% endif %}
-				{% else %}
-				M.toast({'html': 'Du må være logget inn for å opprette reservasjoner.'})
+				    M.toast({'html': 'Du må være logget inn for å opprette reservasjoner.'})
 				{% endif %}
 			},
-			{% if not perms.reservations.view_user_details %}
-			selectAllow: function (selectAllowInfo){
-				return selectAllowInfo.start.getDate() === selectAllowInfo.end.getDate()
-			},
-			{% endif %}
 			events: {
 				url: '/api/reservations/',
 				method: 'GET',
 				extraParams: {
-					parent_queue: {{ queue.pk }}, },
+					parent_queue: {{ queue.pk }}
+                },
 				failure: function() {
 					alert('there was an error while fetching events!');
 				},
@@ -193,7 +184,7 @@
 				const elem = info.el
 				let elemStyle = "white-space: pre-line; overflow-wrap: break-word;";
 				// Add event owner and comment as tooltip for members
-				if (requestUser == info.event.extendedProps.user) {
+				if (requestUser === info.event.extendedProps.user) {
 					elemStyle += "background-color: #5BBA47;";
 					M.Tooltip.init(info.el, {html: "Trykk for å redigere" });
 				} else {

--- a/reservations/templates/reservations/queue_detail.html
+++ b/reservations/templates/reservations/queue_detail.html
@@ -209,8 +209,7 @@
 				comment: $('#id_comment')[0].value,
 				start: $('#id_start')[0].value,
 				end: $('#id_end')[0].value,
-				parent_queue: {{ queue.id }},
-				user: {{ request.user.pk }}
+				parent_queue: {{ queue.id }}
 			}
 
 			$.ajax({

--- a/reservations/templates/reservations/queue_detail.html
+++ b/reservations/templates/reservations/queue_detail.html
@@ -104,9 +104,9 @@
 
 	document.addEventListener('DOMContentLoaded', function() {
 
-		var calendarEl = document.getElementById('calendar');
+		const calendarEl = document.getElementById('calendar');
 
-		var calendar = new FullCalendar.Calendar(calendarEl, {
+		const calendar = new FullCalendar.Calendar(calendarEl, {
 			locale: 'nb',
 			plugins: ['moment', 'interaction', 'timeGrid'],
 			defaultView: window.mobilecheck() ? "timeGridDay" : "timeGridWeek",
@@ -211,7 +211,7 @@
 		calendar.render();
 
 		createButton.addEventListener('click', function() {
-			data = {
+			const data = {
 				comment: $('#id_comment')[0].value,
 				start: $('#id_start')[0].value,
 				end: $('#id_end')[0].value,
@@ -232,7 +232,7 @@
 				},
 				error: function(e) {
 					calendar.refetchEvents();
-					for (var error in e.responseJSON.non_field_errors) {
+					for (const error in e.responseJSON.non_field_errors) {
 						if (e.responseJSON.non_field_errors.hasOwnProperty(error)) {
 							M.toast({html: e.responseJSON.non_field_errors[error]})
 						}
@@ -253,7 +253,7 @@
 				},
 				error: function(e) {
 					calendar.refetchEvents();
-					for (var error in e.responseJSON.non_field_errors) {
+					for (const error in e.responseJSON.non_field_errors) {
 						if (e.responseJSON.non_field_errors.hasOwnProperty(error)) {
 							M.toast({html: e.responseJSON.non_field_errors[error]})
 						}
@@ -263,7 +263,7 @@
 		});
 
 		updateButton.addEventListener('click', function() {
-			data = {
+			const data = {
 				comment: document.getElementById('ex_comment').value,
 			}
 			$.ajax({
@@ -279,7 +279,7 @@
 				},
 				error: function(e) {
 					calendar.refetchEvents();
-					for (var error in e.responseJSON.non_field_errors) {
+					for (const error in e.responseJSON.non_field_errors) {
 						if (e.responseJSON.non_field_errors.hasOwnProperty(error)) {
 							M.toast({html: e.responseJSON.non_field_errors[error]})
 						}

--- a/reservations/templates/reservations/queue_detail.html
+++ b/reservations/templates/reservations/queue_detail.html
@@ -59,7 +59,7 @@
 			<div class="col s12 m6">
 				<div class="card-panel small hs-green white-text z-depth-0">
 					<p>Grønne blokker er dine egne reservasjoner.</p>
-					<p>Trykk en av dine reservasjoner for å oppdatere kommentaren eller slette den.</p>
+					<p>Trykk på en av dine reservasjoner for å oppdatere kommentaren eller slette den.</p>
 				</div>
 			</div>
 			<div class="col s12 m6">

--- a/reservations/templates/reservations/queue_detail.html
+++ b/reservations/templates/reservations/queue_detail.html
@@ -108,6 +108,8 @@
 
 		const calendar = new FullCalendar.Calendar(calendarEl, {
 			locale: 'nb',
+            timeZone: false,
+            now: "{% now "c" %}", // use server time
 			plugins: ['moment', 'interaction', 'timeGrid'],
 			defaultView: window.mobilecheck() ? "timeGridDay" : "timeGridWeek",
 			selectLongPressDelay: 350,
@@ -115,7 +117,7 @@
 			selectable: true,
 			selectMirror: true,
 			selectAllow: function(info) {
-				return moment().diff(info.start) <= 0
+				return moment.utc().diff(info.start) <= 0
 			},
 			height:"auto",
 			allDaySlot: false,
@@ -292,7 +294,7 @@
 	});
 
 	function DateTimeFormat(datetime) {
-		return moment(datetime).format('YYYY-MM-DDTHH:mm:ss');
+		return moment.utc(datetime).format('YYYY-MM-DDTHH:mm:ss');
 	}
 </script>
 {% endblock content %}

--- a/reservations/templates/reservations/queue_detail.html
+++ b/reservations/templates/reservations/queue_detail.html
@@ -119,7 +119,8 @@
 			selectable: true,
 			selectMirror: true,
 			selectAllow: function(info) {
-				return moment.utc().diff(info.start) <= 0
+				return moment.utc().diff(info.startStr) <= 0
+                    && (isMember || info.start.getDate() === info.end.getDate())
 			},
 			height:"auto",
 			allDaySlot: false,

--- a/reservations/views.py
+++ b/reservations/views.py
@@ -36,8 +36,8 @@ class QueueListView(ListView):
 
 
 class SearchDateFilter(filters.FilterSet):
-    start = filters.IsoDateTimeFilter(field_name="start", lookup_expr='gt')
-    end = filters.IsoDateTimeFilter(field_name="end", lookup_expr='lt')
+    end = filters.IsoDateTimeFilter(field_name="start", lookup_expr='lt')
+    start = filters.IsoDateTimeFilter(field_name="end", lookup_expr='gt')
 
     class Meta:
         model = Reservation

--- a/reservations/views.py
+++ b/reservations/views.py
@@ -36,7 +36,10 @@ class QueueListView(ListView):
 
 
 class SearchDateFilter(filters.FilterSet):
+    # filter out events that start after the end time of the search
     end = filters.IsoDateTimeFilter(field_name="start", lookup_expr='lt')
+
+    # filter out events that end before the start time of the search
     start = filters.IsoDateTimeFilter(field_name="end", lookup_expr='gt')
 
     class Meta:

--- a/reservations/views.py
+++ b/reservations/views.py
@@ -3,7 +3,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import ModelViewSet
 from reservations.permissions import IsOwnerOrReadOnly
 from reservations.models import Reservation, Queue
-from reservations.serializers import ReservationsSerializer, RestrictedReservationSerializer
+from reservations.serializers import ReservationsSerializer
 from django_filters import rest_framework as filters
 from datetime import datetime
 
@@ -50,9 +50,7 @@ class ReservationsViewSet(ModelViewSet):
     filterset_class = SearchDateFilter
 
     def get_serializer_class(self):
-        if self.request.user.has_perm('reservations.view_user_details'):
-            return ReservationsSerializer
-        return RestrictedReservationSerializer
+        return ReservationsSerializer
 
     def get_permissions(self):
         if self.action == 'list':


### PR DESCRIPTION
Closes #558 and closes #417

- All reservations are now validated with `ReservationsSerializer`, with the proper rules for non-member.
- The user-attribute has also been moved from the request to the serializer, to prevent someone from reserving for someone else.
- Finally, the PATCH request method now only allows updating the reservation comment attribute. Originally, this method could be used to circumvent all validation and change any attribute of a reservation 🤡
- Oh, and full calendar has received some refactoring and fixes