### PR TITLE
Update article publishing date when draft is published

### DIFF
--- a/news/templates/news/article.html
+++ b/news/templates/news/article.html
@@ -32,7 +32,7 @@
 					{% endif %}
 					<h5 class="hide-on-med-and-up">{{ article.title }}</h5>
 					<h3 class="hide-on-small-only">{{ article.title }}</h3>
-					<p>{{ article.pub_date }}</p>
+					<p>{{ article.pub_date }}{% if article.draft %} <span class="grey-text">(oppdateres ved publisering)</span>{% endif %}</p>
 					{% if article.author %}
 					<p>Skrevet av <a href="{% url 'userprofile:profile_by_id' article.author.id %}">{{ article.author.get_full_name }}</a></p>
 					{% endif %}


### PR DESCRIPTION
Closes #583

The publishing date is now updated when article/event draft status is changed from draft to non-draft (i.e. when the article/event is published). Also added a note about this on the draft article view (pub date is atm not visible on event view).