### PR TITLE
Fix/event ordering

### DIFF
--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -85,7 +85,7 @@
 								</p>
 
 							</li>
-							{% for event in event_list reversed %}
+							{% for event in event_list %}
 								<li class="collection-item">
 									{% if event.time_start > current_date %}
 										<span class="badge white-text hs-green">{{ event.time_start|date:"d.m.Y" }}</span>

--- a/website/views.py
+++ b/website/views.py
@@ -179,7 +179,7 @@ class IndexView(TemplateView):
 
         # Get the 5 events closest to starting
         event_list = list(Event.objects.filter(
-            time_end__gt=timezone.now(),
+            time_start__gt=timezone.now(),
             internal__lte=can_access_internal_event,
             draft=False,
         ).order_by('time_start')[:5])
@@ -188,7 +188,7 @@ class IndexView(TemplateView):
         if len(event_list) < 5:
             to_fill = 5 - len(event_list)
             expired_events = Event.objects.filter(
-                time_end__lte=timezone.now(),
+                time_start__lte=timezone.now(),
                 internal__lte=can_access_internal_event,
                 draft=False,
             ).order_by('time_start')[:to_fill]

--- a/website/views.py
+++ b/website/views.py
@@ -191,7 +191,7 @@ class IndexView(TemplateView):
                 time_start__lte=timezone.now(),
                 internal__lte=can_access_internal_event,
                 draft=False,
-            ).order_by('time_start')[:to_fill]
+            ).order_by('-time_start')[:to_fill]
             event_list += list(expired_events)
 
         current_date = datetime.now()


### PR DESCRIPTION
ref. en av trådene i #dev-public

fikser på rekkefølgen av events slik at det er kommende (i stigende datorekkefølge), deretter utgåtte arrangementer (også i stigende datorekkefølge)