### PR TITLE
Made image categories collapsible

### DIFF
--- a/files/static/files/js/gallery.js
+++ b/files/static/files/js/gallery.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', function() {
+
+    // Initalize collapsibles (one per catagory)
+    var collapsibles = document.querySelectorAll('.collapsible.expandable');
+    M.Collapsible.init(collapsibles, {
+      accordion: false
+    });
+});

--- a/files/templates/files/images-modal.html
+++ b/files/templates/files/images-modal.html
@@ -20,20 +20,22 @@
 		</div>
 
 		<div class="row category-galleries">
+			<ul class="collapsible expandable">
 			{% for category, images in categories.items %}
-				<div class="col s12">
-					<div class="row">
-						<div class="col s12 hs-green white-text">
-							<h4 class="category-header">{{ category }}</h4>
-						</div>
-						<div class="gallery category-{{ category }}">
-							{% for image in images %}
-							{% include 'files/single-image.html' %}
-							{% endfor %}
-						</div>
+			<li class="active">
+				<div class="col s12 hs-green white-text collapsible-header" >
+					<h4 class="category-header">{{ category }}</h4>
+				</div>
+				<div class="col s12 collapsible-body">
+					<div class="gallery category-{{ category }}">
+						{% for image in images %}
+						{% include 'files/single-image.html' %}
+						{% endfor %}
 					</div>
 				</div>
+			</li>
 			{% endfor %}
+			</ul>
 		</div>
 	</div>
 </div>
@@ -76,3 +78,4 @@ thumbModal.addEventListener('galleryUploadSuccess', function(e) {
 	M.toast({ html: 'Bildet er lastet opp og kan velges fra galleriet' });
 });
 </script>
+<script src="{% static 'files/js/gallery.js' %}"></script>

--- a/files/templates/files/images.html
+++ b/files/templates/files/images.html
@@ -8,26 +8,30 @@
 {% include "files/_image_admin_banner.html" %}
 
 {% if categories %}
+<ul class="collapsible expandable">
 {% for category, images in categories.items %}
-<div class="section hs-green white-text">
-	<div class="container">
-		<h4 class="category-header">{{ category }}</h4>
-	</div>
-</div>
-
-<div class="section">
-	<div class="container">
-		<div class="row">
-			{% for image in images %}
-			{% include 'files/single-image-edit.html' %}
-			{% endfor %}
+<li class="active">
+	<div class="section hs-green white-text tab collapsible-header" >
+		<div class="container">
+			<h4 class="category-header">{{ category }}</h4>
 		</div>
 	</div>
-</div>
+	<div class="section collapsible-body">
+		<div class="container">
+			<div class="row">
+				{% for image in images %}
+				{% include 'files/single-image-edit.html' %}
+				{% endfor %}
+			</div>
+		</div>
+	</div>
+</li>
 {% endfor %}
+</ul>
 {% else %}
 <div class="center">
 	<h4>Galleriet er tomt</h4>
 </div>
 {% endif %}
+<script src="{% static 'files/js/gallery.js' %}"></script>
 {% endblock content %}


### PR DESCRIPTION
Images are sorted by categories, but each category can be rather large and it takes a long time to scroll through the whole page.
With this change, all categories are collapsible with the collapsible feature from Materialize.

closes: #579 