### PR TITLE
Fix skills page direct id handling

### DIFF
--- a/userprofile/views.py
+++ b/userprofile/views.py
@@ -154,7 +154,9 @@ class SkillsView(DetailView, CategoryLevelsMixin):
             )
             context["approvable_skills"] = approvable_skills
 
-        context["redirect_skill"] = Skill.objects.get(id=self.kwargs["skill_pk"])
+        # Check if request includes specific skill id
+        if "skill_pk" in self.kwargs:
+            context["redirect_skill"] = Skill.objects.get(id=self.kwargs["skill_pk"])
 
         return context
 


### PR DESCRIPTION
Closes #600 

Some previous refactoring with flake8 caused a 'try-except' to be removed. Without this, an error was thrown if no skill id was provided in the request url. This should be optional, so a simple if check has been added to fix this.