### PR TITLE
Fix django version to ~3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pre-commit==2.15.0
-django>=3.0
+django~=3.0
 django-ckeditor
 coverage
 sorl-thumbnail>=12.6


### PR DESCRIPTION
Closes #601 

Django version is now fixed to 3.0 (and compatible minor releases), since the newly released Django 4.0 has breaking changes. These can be taken care of in the future if we choose to upgrade to 4.0.