### PR TITLE
Add iCalendar feeds for arrangements

### DIFF
--- a/news/event_urls.py
+++ b/news/event_urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .ical import EventFeed
+from .ical import HSEventFeed, HSEventSingleFeed
 
 from . import views
 
@@ -12,5 +12,6 @@ urlpatterns = [
     path("new", views.EventCreateView.as_view(), name="new"),
     path("<int:pk>/delete/", views.EventDeleteView.as_view(), name="delete"),
     path("<int:event_id>/register/", views.register_on_event, name="register"),
-    path("feed.ics", EventFeed()),
+    path("feed.ics", HSEventFeed()),
+    path("<int:pk>/feed.ics", HSEventSingleFeed()),
 ]

--- a/news/event_urls.py
+++ b/news/event_urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from .ical import EventFeed
 
 from . import views
 
@@ -11,4 +12,5 @@ urlpatterns = [
     path("new", views.EventCreateView.as_view(), name="new"),
     path("<int:pk>/delete/", views.EventDeleteView.as_view(), name="delete"),
     path("<int:event_id>/register/", views.register_on_event, name="register"),
+    path("feed.ics", EventFeed()),
 ]

--- a/news/event_urls.py
+++ b/news/event_urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
-from .ical import HSEventFeed, HSEventSingleFeed
 
 from . import views
+from .ical import HSEventFeed, HSEventSingleFeed
 
 app_name = "events"
 urlpatterns = [

--- a/news/ical.py
+++ b/news/ical.py
@@ -38,6 +38,12 @@ class HSEventFeed(ICalFeed):
     def item_link(self, item):
         return reverse('events:details', kwargs={'pk': item.pk})
 
+    def item_location(self, item):
+        return item.place
+
+    def item_organizer(self, item):
+        return f'{item.responsible.first_name} {item.responsible.last_name}'
+
 class HSEventSingleFeed(HSEventFeed):
     """
     Feed for a single event

--- a/news/ical.py
+++ b/news/ical.py
@@ -1,25 +1,27 @@
-from django_ical.views import ICalFeed
-from .models import Event
 from django.urls import reverse
+from django_ical.views import ICalFeed
+
+from .models import Event
+
 
 class HSEventFeed(ICalFeed):
     """
     ICal feed for Hackerspace events
     """
 
-    product_id = '-//hackerspace-ntnu.no//Hackerspace//NB'
-    timezone = 'UTC+01:00'
-    link = '/events/'
-    file_name = 'hackerspace.ics'
+    product_id = "-//hackerspace-ntnu.no//Hackerspace//NB"
+    timezone = "UTC+01:00"
+    link = "/events/"
+    file_name = "hackerspace.ics"
 
     def get_object(self, request):
         return {
-            'internal_access': request.user.has_perm('news.can_view_internal_event')
+            "internal_access": request.user.has_perm("news.can_view_internal_event")
         }
 
     def items(self, attrs):
-        events = Event.objects.all().order_by('-time_start')
-        if not attrs['internal_access']:
+        events = Event.objects.all().order_by("-time_start")
+        if not attrs["internal_access"]:
             events = events.filter(internal=False)
         return events
 
@@ -36,13 +38,14 @@ class HSEventFeed(ICalFeed):
         return item.time_end
 
     def item_link(self, item):
-        return reverse('events:details', kwargs={'pk': item.pk})
+        return reverse("events:details", kwargs={"pk": item.pk})
 
     def item_location(self, item):
         return item.place
 
     def item_organizer(self, item):
-        return f'{item.responsible.first_name} {item.responsible.last_name}'
+        return f"{item.responsible.first_name} {item.responsible.last_name}"
+
 
 class HSEventSingleFeed(HSEventFeed):
     """
@@ -51,16 +54,16 @@ class HSEventSingleFeed(HSEventFeed):
 
     def get_object(self, request, pk=None):
         attrs = super().get_object(request)
-        attrs['id'] = pk
+        attrs["id"] = pk
         return attrs
 
     def items(self, attrs):
         items = super().items(attrs)
-        return items.filter(pk=attrs['id'])
+        return items.filter(pk=attrs["id"])
 
     def file_name(self, attrs):
         items = self.items(attrs)
         if not items:
             return "error_contact_devops.ics"
         title = items[0].title
-        return f'{title}.ics'
+        return f"{title}.ics"

--- a/news/ical.py
+++ b/news/ical.py
@@ -1,0 +1,39 @@
+from django_ical.views import ICalFeed
+from .models import Event
+from django.urls import reverse
+
+class EventFeed(ICalFeed):
+    """
+    A simple event calender
+    """
+
+    product_id = '-//hackerspace-ntnu.no//Hackerspace//NB'
+    timezone = 'UTC+01:00'
+    link = '/events/'
+    file_name = 'hackerspace.ics'
+
+    def get_object(self, request):
+        return {
+            'internal_access': request.user.has_perm('news.can_view_internal_event')
+        }
+
+    def items(self, attrs):
+        events = Event.objects.all().order_by('-time_start')
+        if not attrs['internal_access']:
+            events = events.filter(internal=False)
+        return events
+
+    def item_title(self, item):
+        return item.title
+
+    def item_description(self, item):
+        return item.ingress_content
+
+    def item_start_datetime(self, item):
+        return item.time_start
+    
+    def item_end_datetime(self, item):
+        return item.time_end
+    
+    def item_link(self, item):
+        return reverse('events:details', kwargs={'pk': item.pk})

--- a/news/ical.py
+++ b/news/ical.py
@@ -2,9 +2,9 @@ from django_ical.views import ICalFeed
 from .models import Event
 from django.urls import reverse
 
-class EventFeed(ICalFeed):
+class HSEventFeed(ICalFeed):
     """
-    A simple event calender
+    ICal feed for Hackerspace events
     """
 
     product_id = '-//hackerspace-ntnu.no//Hackerspace//NB'
@@ -31,9 +31,30 @@ class EventFeed(ICalFeed):
 
     def item_start_datetime(self, item):
         return item.time_start
-    
+
     def item_end_datetime(self, item):
         return item.time_end
-    
+
     def item_link(self, item):
         return reverse('events:details', kwargs={'pk': item.pk})
+
+class HSEventSingleFeed(HSEventFeed):
+    """
+    Feed for a single event
+    """
+
+    def get_object(self, request, pk=None):
+        attrs = super().get_object(request)
+        attrs['id'] = pk
+        return attrs
+
+    def items(self, attrs):
+        items = super().items(attrs)
+        return items.filter(pk=attrs['id'])
+
+    def file_name(self, attrs):
+        items = self.items(attrs)
+        if not items:
+            return "error_contact_devops.ics"
+        title = items[0].title
+        return f'{title}.ics'

--- a/news/templates/news/event.html
+++ b/news/templates/news/event.html
@@ -63,6 +63,10 @@
 					{% autoescape off %}
 					{{ event.main_content }}
 					{% endautoescape %}
+					<div class="divider"></div>
+					<p><a href="feed.ics">
+						<button class="btn btn-flat white-text waves-effect waves-light hs-green"><i class="material-icons small">event_note</i> Last ned ICS-fil</button>
+					</a></p>
 				</div>
 			</div>
 		</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ markdown
 pillow
 python-dataporten-auth
 social-auth-app-django==5.0.0
+django-ical>=1.8.3


### PR DESCRIPTION
Per Magnus sitt ønske i #dev-public. Legger til en knapp til alle arrangementer for å laste ned en kalenderfil for det arrangementet. Det er også en skjult lenke (dvs. uten knapp/lenke på nettsiden) som lar deg laste ned en feed som inneholder alle arrangementer (/events/feed.ics)

![bilde](https://user-images.githubusercontent.com/9088854/151236015-782cfad9-3cdc-424d-b093-dc10852c1a65.png)
