### PR TITLE
Remove Instagram badge on front-page

### DIFF
--- a/website/templates/website/_social_buttons.html
+++ b/website/templates/website/_social_buttons.html
@@ -7,7 +7,6 @@
 					<a href="https://hackerspace-ntnu.slack.com" target="_blank"><img src="{% static 'website/img/icon/slack_icon.jpg' %}" title="Slack"></a>
 					<a href="https://www.facebook.com/hackerspacentnu" target="_blank"><img src="{% static 'website/img/icon/if_facebook_386622.svg' %}" title="Facebook"></a>
 					<a href="https://github.com/hackerspace-ntnu/" target="_blank"><img src="{% static 'website/img/icon/if_github_253591.svg' %}" title="GitHub"></a>
-					<a href=https://www.instagram.com/hackerspacentnu/ target="_blank"><img src="{% static 'website/img/icon/INSTAGRAM.svg' %}" title="Instagram"></a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
As suggested by Kristian Skåland in #dev-public. The Instagram presence is heavily outdated (the latest post is from May 2019), and this will probably not change in the foreseeable future.