### PR TITLE
Deduplicate integration workflow on pull requests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,10 @@
 name: Python Integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Closes #616 

The Python Integration workflow currently runs twice for pull requests. With this change, integration will only run on pull requests, and on pushes to master. The latter is to ensure that the integration check is also run after merge to master.

Deduplication is visible in this pull request, as only one check instance runs.