### PR TITLE
Non-secret deploy script with dependency refresh

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,4 +20,14 @@ jobs:
         username: ${{ secrets.user }}
         password: ${{ secrets.id }}
         port: ${{ secrets.port }}
-        script: ${{ secrets.script }}
+        script: |
+          cd ${{ secrets.deploy_dir }}
+          . venv/bin/activate
+          cd website
+          git pull
+          python -m pip install --upgrade pip
+          pip install -r prod_requirements.txt
+          python manage.py migrate
+          python manage.py collectstatic --noinput
+          sudo systemctl restart gunicorn
+


### PR DESCRIPTION
Closes #625 

Currently, the deployment script does not install the newest pip dependencies. This causes failure for changes to the website that require new or updated dependencies (as already seen in #610 and #619).

Also, the deployment script is stored in a GitHub encrypted secret. This makes it hard to debug and make changes, as not even the repo owner can see the secret value, only set a new value.

The proposed change requires that a new secret is created, called `deploy_dir` with the value set to the directory path for the server directory containing the Python virtual environment `venv` and the `website` directory, i.e.

```
<deploy_dir>
 - venv
 - website
```