### PR TITLE
Hotfix: Add event responsible exists check

### DIFF
--- a/news/ical.py
+++ b/news/ical.py
@@ -44,6 +44,8 @@ class HSEventFeed(ICalFeed):
         return item.place
 
     def item_organizer(self, item):
+        if not item.responsible:
+            return ""
         return f"{item.responsible.first_name} {item.responsible.last_name}"
 
 


### PR DESCRIPTION
`/events/feed.ics` gives 500 error since some events don't have a value for the `responsible` user field. Fixed this by adding a simple existence check.