### PR TITLE
Enforce phone number requirement with ongoing or future reservations

### DIFF
--- a/userprofile/forms.py
+++ b/userprofile/forms.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django import forms
 
@@ -20,13 +20,14 @@ class ProfileForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        has_ongoing_or_future_reservations = self.user.reservations.filter(
-            end__gt=datetime.now()
+        has_recent_or_future_reservations = self.user.reservations.filter(
+            end__gt=datetime.now() - timedelta(days=1)
         ).exists()
-        if cleaned_data["phone_number"] is None and has_ongoing_or_future_reservations:
+        if cleaned_data["phone_number"] is None and has_recent_or_future_reservations:
             self.add_error(
                 "phone_number",
-                "Du kan ikke fjerne telefonnummer med pågående eller fremtidige reservasjoner",
+                "Du kan ikke fjerne telefonnummer med nylig gjennomførte (siste 24 timer), pågående eller fremtidige "
+                "reservasjoner",
             )
 
     class Meta:

--- a/userprofile/views.py
+++ b/userprofile/views.py
@@ -149,6 +149,11 @@ class ProfileUpdateView(SuccessMessageMixin, UpdateView):
     success_url = "/profile"
     success_message = "Profilen er oppdatert."
 
+    def get_form_kwargs(self):
+        form_kwargs = super(ProfileUpdateView, self).get_form_kwargs()
+        form_kwargs["user"] = self.request.user
+        return form_kwargs
+
     def get_object(self, **kwargs):
         try:
             userprofile = self.request.user.profile


### PR DESCRIPTION
Closes #541 

This stops a user from removing their registered phone number if they have an ongoing or future reservation (checks if reservation `end` is after current time).