### PR TITLE
Add temporary image upload fix

### DIFF
--- a/files/templates/files/_upload_modal.html
+++ b/files/templates/files/_upload_modal.html
@@ -1,5 +1,5 @@
 {% block head %}
-    {{ jquery | safe }}
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 {% endblock %}
 
 <div class="modal" id="uploadModal">


### PR DESCRIPTION
Temporarily addresses #668

The image modal template tag does not seem to have access to context processors. So for now the context processor tag has been replaced with the hard-coded value. Should look into how to access context processors in template tags, or convert modals to actual templates.