### PR TITLE
Clickable urls in group descriptions

### DIFF
--- a/website/templates/website/about.html
+++ b/website/templates/website/about.html
@@ -62,7 +62,7 @@
 			</div>
 			{% if group.thumbnail %}
 			<div class="col s8">
-				<p class="flow-text">{{ group.description|linebreaks }}</p>
+				<p class="flow-text">{{ group.description|urlize|linebreaks }}</p>
 			</div>
 			<div class="col s4">
 				<br>
@@ -70,7 +70,7 @@
 			</div>
 			{% else %}
 			<div class="col s12">
-				<p class="flow-text">{{ group.description|linebreaks }}</p>
+				<p class="flow-text">{{ group.description|urlize|linebreaks }}</p>
 			</div>
 			{% endif %}
 			<div class="col s8">


### PR DESCRIPTION
Closes #673 

This makes urls (and emails) in the group descriptions clickable. Custom hyperlink text is still not supported. See [Django docs for urlize](https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#urlize) for more info.

![Screenshot 2022-04-01 at 13 17 11](https://user-images.githubusercontent.com/24361490/161253263-1ee5e270-ae8d-4668-af6f-31622593c55f.png)

