### PR TITLE
fix: only those with permission, authors or responsibles can delete

### DIFF
--- a/news/admin.py
+++ b/news/admin.py
@@ -6,7 +6,7 @@ from .models import Article, Event, EventRegistration, Upload
 @admin.register(Event)
 class Eventadmin(admin.ModelAdmin):
     fieldsets = [
-        ("Article", {"fields": ["title", "main_content"]}),
+        ("Article", {"fields": ["title", "main_content", "responsible"]}),
         ("Ingress", {"fields": ["ingress_content"]}),
         (
             "Dates",

--- a/news/templates/news/_event_admin_menu.html
+++ b/news/templates/news/_event_admin_menu.html
@@ -26,7 +26,7 @@
 							</a>
 						</li>
 					{% endif %}
-					{% if perms.news.delete_event %}
+					{% if perms.news.delete_event or is_author_or_responsible %}
 					<li class="collection-item"><a href="/events/{{ event.id }}/delete" class="modal-trigger hs-red-text">
                         <i class="material-icons">delete</i>
                         <span class="collection-icon-text">Slett arrangement</span></a>

--- a/news/templates/news/article.html
+++ b/news/templates/news/article.html
@@ -57,7 +57,7 @@
 				<div class="col s12">
 					<ul class='collection'>
 						<li class="collection-item"><a href="{% url 'news:edit' article.id %}"><i class="material-icons">edit</i><span class="collection-icon-text">Rediger artikkel</span></a></li>
-						{% if perms.news.delete_article %}
+						{% if perms.news.delete_article or is_author %}
 						<li class="collection-item"><a href="{% url 'news:delete' article.id %}" class="modal-trigger hs-red-text"><i class="material-icons">delete</i><span class="collection-icon-text">Slett artikkel</span></a></li>
 						{% endif %}
 					</ul>

--- a/news/templates/news/edit_event.html
+++ b/news/templates/news/edit_event.html
@@ -84,6 +84,10 @@
                             {{ form.responsible }}
                             <label for="id_responsible">{{ form.responsible.label }}</label>
                             <span class="helper-text hs-red-text">{{ form.responsible.errors }}</span>
+                        {% if not is_author_or_responsible %}
+                            <p class="helper-text hs-red-text">Kun den ansvarlige og forfatteren av dette 
+                                    arrangementet kan endre på den ansvarlige</p>
+                        {% endif %}
                         </div>
                         <div class="input-field col s12 m6">
                             <i class="material-icons prefix">date_range</i>

--- a/projectarchive/templates/projectarchive/article.html
+++ b/projectarchive/templates/projectarchive/article.html
@@ -54,8 +54,7 @@
 				</div>
 			</div>
 		</div>
-		
-		{% if perms.projectarticle.change_projectarticle %}
+		{% if perms.projectarchive.change_projectarticle %}
 
 		<!-- Adminpanel -->
 		<div class="card-panel">
@@ -67,7 +66,7 @@
 				<div class="col s12">
 					<ul class='collection'>
 						<li class="collection-item"><a href="{% url 'projectarchive:edit' projectarticle.id %}"><i class="material-icons">edit</i><span class="collection-icon-text">Rediger artikkel</span></a></li>
-						{% if perms.projectarticle.delete_projectarticle %}
+						{% if perms.projectarchive.delete_projectarticle or is_author %}
 						<li class="collection-item"><a href="{% url 'projectarchive:delete' projectarticle.id %}" class="modal-trigger hs-red-text"><i class="material-icons">delete</i><span class="collection-icon-text">Slett artikkel</span></a></li>
 						{% endif %}
 					</ul>

--- a/projectarchive/views.py
+++ b/projectarchive/views.py
@@ -31,7 +31,7 @@ class ArticleListView(ListView):
         context = super().get_context_data(**kwargs)
 
         # Retrieve any user drafts if logged in
-        if self.request.user.has_perm("projectarchive.add_article"):
+        if self.request.user.has_perm("projectarchive.add_projectarticle"):
             context["drafts"] = Projectarticle.objects.order_by("-pub_date").filter(
                 author=self.request.user, draft=True
             )
@@ -63,6 +63,8 @@ class ArticleView(DetailView):
 
         context = super().get_context_data(**kwargs)
 
+        context["is_author"] = self.request.user == self.object.author
+
         return context
 
 
@@ -70,7 +72,7 @@ class ArticleCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateView
     model = Projectarticle
     form_class = ArticleForm
     template_name = "projectarchive/edit_article.html"
-    permission_required = "projectarchive.add_article"
+    permission_required = "projectarchive.add_projectarticle"
 
     def get_success_message(self, cleaned_data):
         if self.object.draft:
@@ -89,7 +91,7 @@ class ArticleUpdateView(PermissionRequiredMixin, SuccessMessageMixin, UpdateView
     model = Projectarticle
     form_class = ArticleForm
     template_name = "projectarchive/edit_article.html"
-    permission_required = "projectarchive.change_article"
+    permission_required = "projectarchive.change_projectarticle"
     success_message = "Artikkelen er oppdatert."
 
     def get_success_url(self):
@@ -99,4 +101,11 @@ class ArticleUpdateView(PermissionRequiredMixin, SuccessMessageMixin, UpdateView
 class ArticleDeleteView(PermissionRequiredMixin, DeleteView):
     model = Projectarticle
     success_url = "/projectarchive/"
-    permission_required = "projectarchive.delete_article"
+    permission_required = "projectarchive.delete_projectarticle"
+
+    def has_permission(self):
+        user = self.request.user
+        
+        perms = self.get_permission_required()
+        print(user, self.get_object().author)
+        return user.has_perms(perms) or self.get_object().author == user


### PR DESCRIPTION
Added better permission handling for events, news and project articles. From now on, these objects can only be deleted by its author/responsible or those with explicit permission.
It is therefore important that we remove the delete permissions from all groups except Ledelsen and DevOps in the admin panel.
This way we will not have another Febrauary incident where an event was accidently deleted.
It is important to remember that LabOps can still change these articles and events but not delete unless they are the author/responsible.
I have also added another "security feature" where only the author/responsible can change the person that is responsible for an event. Without this, it would be possible for someone who can not delete, but change, an event to change the person responsible to themselves and then delete it. Max security