### PR TITLE
change permissions from article to projectarticle

### DIFF
--- a/projectarchive/views.py
+++ b/projectarchive/views.py
@@ -31,7 +31,7 @@ class ArticleListView(ListView):
         context = super().get_context_data(**kwargs)
 
         # Retrieve any user drafts if logged in
-        if self.request.user.has_perm("projectarchive.add_article"):
+        if self.request.user.has_perm("projectarchive.add_projectarticle"):
             context["drafts"] = Projectarticle.objects.order_by("-pub_date").filter(
                 author=self.request.user, draft=True
             )
@@ -70,7 +70,7 @@ class ArticleCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateView
     model = Projectarticle
     form_class = ArticleForm
     template_name = "projectarchive/edit_article.html"
-    permission_required = "projectarchive.add_article"
+    permission_required = "projectarchive.add_projectarticle"
 
     def get_success_message(self, cleaned_data):
         if self.object.draft:
@@ -89,7 +89,7 @@ class ArticleUpdateView(PermissionRequiredMixin, SuccessMessageMixin, UpdateView
     model = Projectarticle
     form_class = ArticleForm
     template_name = "projectarchive/edit_article.html"
-    permission_required = "projectarchive.change_article"
+    permission_required = "projectarchive.change_projectarticle"
     success_message = "Artikkelen er oppdatert."
 
     def get_success_url(self):
@@ -99,4 +99,4 @@ class ArticleUpdateView(PermissionRequiredMixin, SuccessMessageMixin, UpdateView
 class ArticleDeleteView(PermissionRequiredMixin, DeleteView):
     model = Projectarticle
     success_url = "/projectarchive/"
-    permission_required = "projectarchive.delete_article"
+    permission_required = "projectarchive.delete_projectarticle"


### PR DESCRIPTION
In the projectarchive views file, the permissions reference add_article while it should instead be add_projectarticle.  Other relevant permissions has also been updated. This meant that it was not possible to create, change or delete project articles.