### PR TITLE
updated pre-commit from gitlab to github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
     - id: isort
       entry: isort --profile=black
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.7.9
     hooks:
     - id: flake8


### PR DESCRIPTION
The flake8 repo has been moved from gitlab to github which prevented it to be used. Which repository pre-commit gets flake8 from is now changed in the pre-commit config file.