### PR TITLE
la til automatisk høyde på progress bar

### DIFF
--- a/news/static/news/css/news_style.css
+++ b/news/static/news/css/news_style.css
@@ -2,3 +2,6 @@
 	margin-top: -96px !important;
 	position: relative;
 }
+.progress {
+	height: auto;
+}


### PR DESCRIPTION
La til automatisk høyde på progress bar i påmelding. Materialize css hadde en oppdatering som gjorde at dette ble nødvendig. 
Closes: #701 