### PR TITLE
add relative position to p tag in progress

### DIFF
--- a/news/static/news/css/news_style.css
+++ b/news/static/news/css/news_style.css
@@ -7,6 +7,10 @@
 	height: auto;
 }
 
+.progress p {
+	position: relative
+}
+
 div,h3{
 	word-wrap: break-word;      
 }


### PR DESCRIPTION
closes: #710 

Fixed a bug where the information about number of people registered for an event was hidden behind the progress bar.
This is fixed with setting the p tag in the progress bar to have a relative position.