### PR TITLE
added password to sudo command in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,4 +29,4 @@ jobs:
           pip install --upgrade --force-reinstall -r prod_requirements.txt
           python manage.py migrate
           python manage.py collectstatic --noinput
-          sudo systemctl restart gunicorn
+          echo "${{ secrets.dingseboms_password }}" | sudo -S systemctl restart gunicorn


### PR DESCRIPTION
The deploy script fails each time it is run because a sudo command is run. Sudo requires password input from standard input which is not given to it. The `sudo systemctl restart gunicorn` command is switched to `echo "${{ secrets.dingseboms_password }}" | sudo -S systemctl restart gunicorn`. Here means `-S` to read from standard output which echo prints to.