### PR TITLE
make organization to list of responsible

### DIFF
--- a/news/ical.py
+++ b/news/ical.py
@@ -44,9 +44,12 @@ class HSEventFeed(ICalFeed):
         return item.place
 
     def item_organizer(self, item):
-        if not item.responsible:
-            return ""
-        return f"{item.responsible.first_name} {item.responsible.last_name}"
+        return ",".join(
+            [
+                f"{responsible.first_name} {responsible.last_name}"
+                for responsible in item.responsibles.all()
+            ]
+        )
 
 
 class HSEventSingleFeed(HSEventFeed):


### PR DESCRIPTION
Fixes bug where ical download crashed because of several responsible people. This has now been changed to join the responsible people to a list of people
![image](https://github.com/hackerspace-ntnu/website/assets/70779496/f82370d3-644a-4124-816d-97729607e28e)
