### PR TITLE
updates locales and add date supported formats

### DIFF
--- a/files/locale/en/LC_MESSAGES/django.po
+++ b/files/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-03 20:23+0200\n"
+"POT-Creation-Date: 2024-04-11 12:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,7 +57,7 @@ msgid "Last opp bilde"
 msgstr "Upload new image"
 
 #: files/templates/files/image_confirm_delete.html:4
-msgid "Are you sure you want to delete "
+msgid "Er du sikker på at du vil slette "
 msgstr "Are you sure you want to delete "
 
 #: files/templates/files/images-modal.html:8
@@ -95,3 +95,6 @@ msgstr "Delete"
 #: files/templates/files/single-image.html:12
 msgid "Velg"
 msgstr "Select"
+
+#~ msgid "Are you sure you want to delete "
+#~ msgstr "Are you sure you want to delete "

--- a/files/locale/nb/LC_MESSAGES/django.po
+++ b/files/locale/nb/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-03 20:23+0200\n"
+"POT-Creation-Date: 2024-04-11 12:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,7 +56,7 @@ msgid "Last opp bilde"
 msgstr ""
 
 #: files/templates/files/image_confirm_delete.html:4
-msgid "Are you sure you want to delete "
+msgid "Er du sikker på at du vil slette "
 msgstr ""
 
 #: files/templates/files/images-modal.html:8

--- a/files/templates/files/image_confirm_delete.html
+++ b/files/templates/files/image_confirm_delete.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
 <form method="post">{% csrf_token %}
-    <p>{% trans "Are you sure you want to delete " %}{{ object }}?</p>
+    <p>{% trans "Er du sikker på at du vil slette " %}{{ object }}?</p>
     <input type="submit" value="Confirm">
 </form>

--- a/inventory/locale/en/LC_MESSAGES/django.po
+++ b/inventory/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-11 00:10+0200\n"
+"POT-Creation-Date: 2024-04-11 12:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,51 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: inventory/models/item.py:16 inventory/templates/inventory/inventory.html:25
+#: inventory/templates/inventory/inventory.html:33
+msgid "Navn"
+msgstr "Name"
+
+#: inventory/models/item.py:17 inventory/templates/inventory/inventory.html:31
+#: inventory/templates/inventory/inventory.html:32
+msgid "Lagerbeholdning"
+msgstr "Inventory Quantity"
+
+#: inventory/models/item.py:19
+#, fuzzy
+#| msgid "Lagerbeholdning"
+msgid "Ukjent lagerbeholdning"
+msgstr "Inventory Quantity"
+
+#: inventory/models/item.py:22
+msgid "Kan lånes"
+msgstr "Can be borrowed"
+
+#: inventory/models/item.py:24
+msgid "Beskrivelse"
+msgstr "Description"
+
+#: inventory/models/item.py:26
+msgid "Bilde"
+msgstr "Image"
+
+#: inventory/models/item.py:28 inventory/templates/inventory/items_list.html:30
+msgid "Hylleplass"
+msgstr "Shelf Location"
+
+#: inventory/models/item.py:30
+msgid "Maks lånevarighet (dager)"
+msgstr "Max borrow duration (days)"
+
+#: inventory/models/item.py:33
+msgid "Detaljsidevisninger"
+msgstr "Page views"
+
 #: inventory/models/item_loan.py:25
 msgid "Lån fra"
 msgstr "Borrow from"
 
-#: inventory/templates/inventory/edit_item.html:13
+#: inventory/templates/inventory/edit_item.html:11
 msgid "Rediger lagerinnslag"
 msgstr "Edit inventory item"
 
@@ -58,11 +98,6 @@ msgstr "View equipment and apparatus"
 msgid "Ting, tang og tare"
 msgstr "Things and stuff"
 
-#: inventory/templates/inventory/inventory.html:25
-#: inventory/templates/inventory/inventory.html:33
-msgid "Navn"
-msgstr "Name"
-
 #: inventory/templates/inventory/inventory.html:29
 msgid "Velg sorteringskriterie"
 msgstr "Choose sorting criterion"
@@ -70,11 +105,6 @@ msgstr "Choose sorting criterion"
 #: inventory/templates/inventory/inventory.html:30
 msgid "Popularitet"
 msgstr "Popularity"
-
-#: inventory/templates/inventory/inventory.html:31
-#: inventory/templates/inventory/inventory.html:32
-msgid "Lagerbeholdning"
-msgstr "Inventory Quantity"
 
 #: inventory/templates/inventory/inventory.html:31
 msgid "Synkende"
@@ -105,10 +135,6 @@ msgstr "None"
 #: inventory/templates/inventory/items_list.html:27
 msgid "på lager"
 msgstr "in stock"
-
-#: inventory/templates/inventory/items_list.html:30
-msgid "Hylleplass"
-msgstr "Shelf Location"
 
 #: inventory/templates/inventory/items_list.html:34
 msgid "forventet på lager"
@@ -142,10 +168,16 @@ msgstr "Loan applications"
 msgid "Oversikt over lånesøknader"
 msgstr "Overview of loan applications"
 
-#: inventory/views/item_loan.py:107
+#: inventory/views/item_loan.py:102
 msgid "Lånesøknaden er avslått"
 msgstr "Loan applications is denied"
 
-#: inventory/views/item_loan.py:124
+#: inventory/views/item_loan.py:119
 msgid "Lånesøknaden er lukket"
 msgstr "Loan application is closed"
+
+#: inventory/views/item_loan.py:146
+#, fuzzy
+#| msgid "Lånesøknaden er avslått"
+msgid "Lånesøknaden er registrert!"
+msgstr "Loan applications is denied"

--- a/inventory/locale/nb/LC_MESSAGES/django.po
+++ b/inventory/locale/nb/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-11 00:09+0200\n"
+"POT-Creation-Date: 2024-04-11 12:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,49 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: inventory/models/item.py:16 inventory/templates/inventory/inventory.html:25
+#: inventory/templates/inventory/inventory.html:33
+msgid "Navn"
+msgstr ""
+
+#: inventory/models/item.py:17 inventory/templates/inventory/inventory.html:31
+#: inventory/templates/inventory/inventory.html:32
+msgid "Lagerbeholdning"
+msgstr ""
+
+#: inventory/models/item.py:19
+msgid "Ukjent lagerbeholdning"
+msgstr ""
+
+#: inventory/models/item.py:22
+msgid "Kan lånes"
+msgstr ""
+
+#: inventory/models/item.py:24
+msgid "Beskrivelse"
+msgstr ""
+
+#: inventory/models/item.py:26
+msgid "Bilde"
+msgstr ""
+
+#: inventory/models/item.py:28 inventory/templates/inventory/items_list.html:30
+msgid "Hylleplass"
+msgstr ""
+
+#: inventory/models/item.py:30
+msgid "Maks lånevarighet (dager)"
+msgstr ""
+
+#: inventory/models/item.py:33
+msgid "Detaljsidevisninger"
+msgstr ""
+
 #: inventory/models/item_loan.py:25
 msgid "Lån fra"
 msgstr ""
 
-#: inventory/templates/inventory/edit_item.html:13
+#: inventory/templates/inventory/edit_item.html:11
 msgid "Rediger lagerinnslag"
 msgstr ""
 
@@ -53,22 +91,12 @@ msgstr ""
 msgid "Ting, tang og tare"
 msgstr ""
 
-#: inventory/templates/inventory/inventory.html:25
-#: inventory/templates/inventory/inventory.html:33
-msgid "Navn"
-msgstr ""
-
 #: inventory/templates/inventory/inventory.html:29
 msgid "Velg sorteringskriterie"
 msgstr ""
 
 #: inventory/templates/inventory/inventory.html:30
 msgid "Popularitet"
-msgstr ""
-
-#: inventory/templates/inventory/inventory.html:31
-#: inventory/templates/inventory/inventory.html:32
-msgid "Lagerbeholdning"
 msgstr ""
 
 #: inventory/templates/inventory/inventory.html:31
@@ -99,10 +127,6 @@ msgstr ""
 
 #: inventory/templates/inventory/items_list.html:27
 msgid "på lager"
-msgstr ""
-
-#: inventory/templates/inventory/items_list.html:30
-msgid "Hylleplass"
 msgstr ""
 
 #: inventory/templates/inventory/items_list.html:34
@@ -137,10 +161,14 @@ msgstr ""
 msgid "Oversikt over lånesøknader"
 msgstr ""
 
-#: inventory/views/item_loan.py:107
+#: inventory/views/item_loan.py:102
 msgid "Lånesøknaden er avslått"
 msgstr ""
 
-#: inventory/views/item_loan.py:124
+#: inventory/views/item_loan.py:119
 msgid "Lånesøknaden er lukket"
+msgstr ""
+
+#: inventory/views/item_loan.py:146
+msgid "Lånesøknaden er registrert!"
 msgstr ""

--- a/inventory/views/item_loan.py
+++ b/inventory/views/item_loan.py
@@ -143,9 +143,10 @@ class ItemLoanApplicationView(CreateView):
         "consent",
     ]
     template_name = "inventory/loan_apply.html"
-    success_message = "Lånesøknaden er registrert!"
+    success_message = _("Lånesøknaden er registrert!")
     success_url = reverse_lazy("inventory:inventory")
     months_max_ahead = 1
+    date_format = "%d.%m.%Y"
 
     def get_success_url(self):
         # SuccessMessageMixin doesn't actually work so fuck it
@@ -187,8 +188,11 @@ class ItemLoanApplicationView(CreateView):
         form = super().get_form(*args, **kwargs)
         form.fields["loan_to"].widget.attrs["class"] = "datepicker"
         form.fields["loan_from"].widget.attrs["class"] = "datepicker"
-        form.fields["loan_from"].widget.format = "%d.%m.%Y"  # Set date format
-        form.fields["loan_to"].widget.format = "%d.%m.%Y"  # Set date format
+        form.fields["loan_from"].widget.format = self.date_format
+        form.fields["loan_to"].widget.format = self.date_format
+        form.fields["loan_from"].input_formats.append(self.date_format)
+        form.fields["loan_to"].input_formats.append(self.date_format)
+        print(form.fields["loan_from"].input_formats)
         return form
 
     def get_context_data(self, **kwargs):

--- a/news/locale/en/LC_MESSAGES/django.po
+++ b/news/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-11 00:10+0200\n"
+"POT-Creation-Date: 2024-04-11 12:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,9 +12,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: news/forms.py:179
+#: news/forms.py:170
 msgid "Arrangementansvarlig"
 msgstr "Event organizer"
+
+#: news/forms.py:181
+msgid "Bruker er ikke i en registert gruppe."
+msgstr "User is not registered in a group."
 
 #: news/templates/news/_event-list-element.html:13
 msgid "Skjer nå!"
@@ -35,7 +39,7 @@ msgid "Administrator-meny"
 msgstr "Administrator Menu"
 
 #: news/templates/news/_event_admin_menu.html:14
-#: news/templates/news/edit_event.html:21
+#: news/templates/news/edit_event.html:19
 msgid "Rediger arrangement"
 msgstr "Edit event"
 
@@ -132,7 +136,7 @@ msgstr "Read"
 msgid "ganger"
 msgstr "times"
 
-#: news/templates/news/article.html:61 news/templates/news/edit_article.html:12
+#: news/templates/news/article.html:61 news/templates/news/edit_article.html:10
 msgid "Rediger artikkel"
 msgstr "Edit article"
 
@@ -157,6 +161,7 @@ msgid "Ingen nyere artikler"
 msgstr "No newer articles"
 
 #: news/templates/news/article_confirm_delete.html:12
+#: news/templates/news/event_confirm_delete.html:12
 msgid "Bekreft handling"
 msgstr "Confirm action"
 
@@ -165,18 +170,22 @@ msgid "Er du sikker på at du vil slette følgende artikkel?"
 msgstr "Are you sure you want to delete the following article?"
 
 #: news/templates/news/article_confirm_delete.html:16
+#: news/templates/news/event_confirm_delete.html:16
 msgid "Tittel"
 msgstr "Title"
 
 #: news/templates/news/article_confirm_delete.html:17
+#: news/templates/news/event_confirm_delete.html:17
 msgid "Publiseringsdato"
 msgstr "Publication date"
 
 #: news/templates/news/article_confirm_delete.html:19
+#: news/templates/news/event_confirm_delete.html:19
 msgid "JA"
 msgstr "YES"
 
 #: news/templates/news/article_confirm_delete.html:22
+#: news/templates/news/event_confirm_delete.html:22
 msgid "NEI, GÅ TILBAKE"
 msgstr "NO, GO BACK"
 
@@ -197,51 +206,42 @@ msgstr "Attended"
 msgid "Lagre"
 msgstr "Save"
 
-#: news/templates/news/edit_article.html:21
-#: news/templates/news/edit_event.html:34
+#: news/templates/news/edit_article.html:19
+#: news/templates/news/edit_event.html:32
 msgid "Innhold"
 msgstr "Content"
 
-#: news/templates/news/edit_article.html:42
-#: news/templates/news/edit_event.html:56
-msgid ""
-"Bare markdown støttes i dette feltet, html blir returnert som plaintext. "
-"Bilder kan legges til ved drag-and-drop."
-msgstr ""
-"Only markdown is supported in this field, HTML will be returned as "
-"plaintext. Images can be added using drag-and-drop."
-
-#: news/templates/news/edit_article.html:74
-#: news/templates/news/edit_article.html:75
+#: news/templates/news/edit_article.html:65
+#: news/templates/news/edit_article.html:66
 msgid "Lagre og publiser artikkel"
 msgstr "Save and publish article"
 
-#: news/templates/news/edit_article.html:76
-#: news/templates/news/edit_event.html:248
+#: news/templates/news/edit_article.html:67
+#: news/templates/news/edit_event.html:239
 msgid "Lagre som utkast"
 msgstr "Save as draft"
 
-#: news/templates/news/edit_event.html:66
+#: news/templates/news/edit_event.html:57
 msgid "Velg hovedbilde"
 msgstr "Select main image"
 
-#: news/templates/news/edit_event.html:89
+#: news/templates/news/edit_event.html:80
 msgid "Internt arrangement (Kun Hackerspace-medlemmer kan se arrangementet)"
 msgstr "Internal event (Only Hackerspace members can see the event)"
 
-#: news/templates/news/edit_event.html:156 news/templates/news/event.html:105
+#: news/templates/news/edit_event.html:147 news/templates/news/event.html:105
 msgid "Påmelding"
 msgstr "Registration"
 
-#: news/templates/news/edit_event.html:190
+#: news/templates/news/edit_event.html:181
 msgid "Ferdigheter"
 msgstr "Skills"
 
-#: news/templates/news/edit_event.html:207 news/templates/news/event.html:155
+#: news/templates/news/edit_event.html:198 news/templates/news/event.html:155
 msgid "Filer"
 msgstr "Files"
 
-#: news/templates/news/edit_event.html:208
+#: news/templates/news/edit_event.html:199
 msgid ""
 "Det kan være nyttig å legge ved powerpoint eller andre relevante filer i "
 "arrangementet. Da får deltakerene mulighet til å gjøre seg klare før "
@@ -250,40 +250,40 @@ msgstr ""
 "It can be beneficial to add relevant documents to let participants prepare "
 "ahead of time."
 
-#: news/templates/news/edit_event.html:227
+#: news/templates/news/edit_event.html:218
 msgid "Ferdig"
 msgstr "Done"
 
-#: news/templates/news/edit_event.html:242
-#: news/templates/news/edit_event.html:245
+#: news/templates/news/edit_event.html:233
+#: news/templates/news/edit_event.html:236
 msgid "Lagre og publiser arrangement"
 msgstr "Save and publish event"
 
-#: news/templates/news/edit_event.html:270
+#: news/templates/news/edit_event.html:261
 msgid "Kunne ikke hente flere resultater"
 msgstr "The results could not be loaded"
 
-#: news/templates/news/edit_event.html:271
+#: news/templates/news/edit_event.html:262
 msgid "Vennligst skriv inn flere tegn"
 msgstr "Please add more characters"
 
-#: news/templates/news/edit_event.html:272
+#: news/templates/news/edit_event.html:263
 msgid "Vennligst skriv inn færre tegn"
 msgstr "Please remove characters"
 
-#: news/templates/news/edit_event.html:273
+#: news/templates/news/edit_event.html:264
 msgid "Laster flere resultater"
 msgstr "Loading more results"
 
-#: news/templates/news/edit_event.html:274
+#: news/templates/news/edit_event.html:265
 msgid "Du kan ikke velge flere"
 msgstr "You cannot choose more"
 
-#: news/templates/news/edit_event.html:275
+#: news/templates/news/edit_event.html:266
 msgid "Ingen resultater"
 msgstr "No results found"
 
-#: news/templates/news/edit_event.html:276
+#: news/templates/news/edit_event.html:267
 msgid "Fjern alle"
 msgstr "Remove all"
 
@@ -445,29 +445,11 @@ msgstr "are up to date."
 msgid "Cancel"
 msgstr "Cancel"
 
-#: news/templates/news/event_confirm_delete.html:12
-msgid "Confirm Action"
-msgstr "Confirm Action"
-
 #: news/templates/news/event_confirm_delete.html:13
-msgid "Are you sure you want to delete the following event?"
-msgstr "Are you sure you want to delete the following event?"
-
-#: news/templates/news/event_confirm_delete.html:16
-msgid "Title"
-msgstr ""
-
-#: news/templates/news/event_confirm_delete.html:17
-msgid "Publication Date"
-msgstr ""
-
-#: news/templates/news/event_confirm_delete.html:19
-msgid "YES"
-msgstr ""
-
-#: news/templates/news/event_confirm_delete.html:22
-msgid "NO, GO BACK"
-msgstr ""
+#, fuzzy
+#| msgid "Er du sikker på at du vil slette følgende artikkel?"
+msgid "Er du sikker på at du vil slette følgende arrangement?"
+msgstr "Are you sure you want to delete the following article?"
 
 #: news/templates/news/events.html:10
 msgid "Arrangementer"
@@ -528,3 +510,4 @@ msgstr "Attendance Not Registered"
 #: news/templates/news/skills_form.html:87
 msgid "Save"
 msgstr "Save"
+

--- a/news/locale/nb/LC_MESSAGES/django.po
+++ b/news/locale/nb/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-11 00:09+0200\n"
+"POT-Creation-Date: 2024-04-11 12:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,8 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: news/forms.py:179
+#: news/forms.py:170
 msgid "Arrangementansvarlig"
+msgstr ""
+
+#: news/forms.py:181
+msgid "Bruker er ikke i en registert gruppe."
 msgstr ""
 
 #: news/templates/news/_event-list-element.html:13
@@ -41,7 +45,7 @@ msgid "Administrator-meny"
 msgstr ""
 
 #: news/templates/news/_event_admin_menu.html:14
-#: news/templates/news/edit_event.html:21
+#: news/templates/news/edit_event.html:19
 msgid "Rediger arrangement"
 msgstr ""
 
@@ -138,7 +142,7 @@ msgstr ""
 msgid "ganger"
 msgstr ""
 
-#: news/templates/news/article.html:61 news/templates/news/edit_article.html:12
+#: news/templates/news/article.html:61 news/templates/news/edit_article.html:10
 msgid "Rediger artikkel"
 msgstr ""
 
@@ -163,6 +167,7 @@ msgid "Ingen nyere artikler"
 msgstr ""
 
 #: news/templates/news/article_confirm_delete.html:12
+#: news/templates/news/event_confirm_delete.html:12
 msgid "Bekreft handling"
 msgstr ""
 
@@ -171,18 +176,22 @@ msgid "Er du sikker på at du vil slette følgende artikkel?"
 msgstr ""
 
 #: news/templates/news/article_confirm_delete.html:16
+#: news/templates/news/event_confirm_delete.html:16
 msgid "Tittel"
 msgstr ""
 
 #: news/templates/news/article_confirm_delete.html:17
+#: news/templates/news/event_confirm_delete.html:17
 msgid "Publiseringsdato"
 msgstr ""
 
 #: news/templates/news/article_confirm_delete.html:19
+#: news/templates/news/event_confirm_delete.html:19
 msgid "JA"
 msgstr ""
 
 #: news/templates/news/article_confirm_delete.html:22
+#: news/templates/news/event_confirm_delete.html:22
 msgid "NEI, GÅ TILBAKE"
 msgstr ""
 
@@ -203,89 +212,82 @@ msgstr ""
 msgid "Lagre"
 msgstr ""
 
-#: news/templates/news/edit_article.html:21
-#: news/templates/news/edit_event.html:34
+#: news/templates/news/edit_article.html:19
+#: news/templates/news/edit_event.html:32
 msgid "Innhold"
 msgstr ""
 
-#: news/templates/news/edit_article.html:42
-#: news/templates/news/edit_event.html:56
-msgid ""
-"Bare markdown støttes i dette feltet, html blir returnert som plaintext. "
-"Bilder kan legges til ved drag-and-drop."
-msgstr ""
-
-#: news/templates/news/edit_article.html:74
-#: news/templates/news/edit_article.html:75
+#: news/templates/news/edit_article.html:65
+#: news/templates/news/edit_article.html:66
 msgid "Lagre og publiser artikkel"
 msgstr ""
 
-#: news/templates/news/edit_article.html:76
-#: news/templates/news/edit_event.html:248
+#: news/templates/news/edit_article.html:67
+#: news/templates/news/edit_event.html:239
 msgid "Lagre som utkast"
 msgstr ""
 
-#: news/templates/news/edit_event.html:66
+#: news/templates/news/edit_event.html:57
 msgid "Velg hovedbilde"
 msgstr ""
 
-#: news/templates/news/edit_event.html:89
+#: news/templates/news/edit_event.html:80
 msgid "Internt arrangement (Kun Hackerspace-medlemmer kan se arrangementet)"
 msgstr ""
 
-#: news/templates/news/edit_event.html:156 news/templates/news/event.html:105
+#: news/templates/news/edit_event.html:147 news/templates/news/event.html:105
 msgid "Påmelding"
 msgstr ""
 
-#: news/templates/news/edit_event.html:190
+#: news/templates/news/edit_event.html:181
 msgid "Ferdigheter"
 msgstr ""
 
-#: news/templates/news/edit_event.html:207 news/templates/news/event.html:155
+#: news/templates/news/edit_event.html:198 news/templates/news/event.html:155
 msgid "Filer"
 msgstr ""
 
-#: news/templates/news/edit_event.html:208
+#: news/templates/news/edit_event.html:199
 msgid ""
 "Det kan være nyttig å legge ved powerpoint eller andre relevante filer i "
 "arrangementet. Da får deltakerene mulighet til å gjøre seg klare før "
 "arrangementet starter."
 msgstr ""
 
-#: news/templates/news/edit_event.html:227
+#: news/templates/news/edit_event.html:218
 msgid "Ferdig"
 msgstr ""
 
-#: news/templates/news/edit_event.html:242
-#: news/templates/news/edit_event.html:245
+#: news/templates/news/edit_event.html:233
+#: news/templates/news/edit_event.html:236
 msgid "Lagre og publiser arrangement"
 msgstr ""
 
-#: news/templates/news/edit_event.html:270
+#: news/templates/news/edit_event.html:261
 msgid "Kunne ikke hente flere resultater"
 msgstr ""
 
-#: news/templates/news/edit_event.html:271
+#: news/templates/news/edit_event.html:262
 msgid "Vennligst skriv inn flere tegn"
 msgstr ""
 
-#: news/templates/news/edit_event.html:272
+#: news/templates/news/edit_event.html:263
 msgid "Vennligst skriv inn færre tegn"
 msgstr ""
 
-#: news/templates/news/edit_event.html:273
+#: news/templates/news/edit_event.html:264
 msgid "Laster flere resultater"
 msgstr ""
 
-#: news/templates/news/edit_event.html:274
+#: news/templates/news/edit_event.html:265
 msgid "Du kan ikke velge flere"
 msgstr ""
 
-#: news/templates/news/edit_event.html:275
+#: news/templates/news/edit_event.html:266
 msgid "Ingen resultater"
 msgstr ""
 
-#: news/templates/news/edit_event.html:276
+#: news/templates/news/edit_event.html:267
 msgid "Fjern alle"
 msgstr ""
 
@@ -441,28 +443,8 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: news/templates/news/event_confirm_delete.html:12
-msgid "Confirm Action"
-msgstr ""
-
 #: news/templates/news/event_confirm_delete.html:13
-msgid "Are you sure you want to delete the following event?"
-msgstr ""
-
-#: news/templates/news/event_confirm_delete.html:16
-msgid "Title"
-msgstr ""
-
-#: news/templates/news/event_confirm_delete.html:17
-msgid "Publication Date"
-msgstr ""
-
-#: news/templates/news/event_confirm_delete.html:19
-msgid "YES"
-msgstr ""
-
-#: news/templates/news/event_confirm_delete.html:22
-msgid "NO, GO BACK"
+msgid "Er du sikker på at du vil slette følgende arrangement?"
 msgstr ""
 
 #: news/templates/news/events.html:10

--- a/news/templates/news/event_confirm_delete.html
+++ b/news/templates/news/event_confirm_delete.html
@@ -9,17 +9,17 @@
                     <div class="col s12">
                         <form method="post">
                             {% csrf_token %}
-                            <h3>{% trans "Confirm Action" %}</h3>
-                            <p>{% trans "Are you sure you want to delete the following event?" %}</p>
+                            <h3>{% trans "Bekreft handling" %}</h3>
+                            <p>{% trans "Er du sikker på at du vil slette følgende arrangement?" %}</p>
                             <ul>
                                 <li>ID: {{ object.id }}</li>
-                                <li>{% trans "Title" %}: {{ object.title }}</li>
-                                <li>{% trans "Publication Date" %}: {{ object.pub_date }}</li>
+                                <li>{% trans "Tittel" %}: {{ object.title }}</li>
+                                <li>{% trans "Publiseringsdato" %}: {{ object.pub_date }}</li>
                             </ul>
-                            <input class="btn btn-large hs-red" type="submit" value="{% trans "YES" %}" />
+                            <input class="btn btn-large hs-red" type="submit" value="{% trans "JA" %}" />
                         </form>
                         <br><br>
-                        <a href="{% url 'news:all' %}" class="btn btn-large hs-green">{% trans "NO, GO BACK" %}</a>
+                        <a href="{% url 'news:all' %}" class="btn btn-large hs-green">{% trans "NEI, GÅ TILBAKE" %}</a>
                     </div>
                 </div>
             </div>

--- a/projectarchive/locale/en/LC_MESSAGES/django.po
+++ b/projectarchive/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-13 23:06+0100\n"
+"POT-Creation-Date: 2024-04-11 12:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: projectarchive/templates/projectarchive/edit_article.html:12
+#: projectarchive/templates/projectarchive/edit_article.html:10
 msgid "Rediger prosjektartikkel"
 msgstr "Edit project article"
 

--- a/projectarchive/locale/nb/LC_MESSAGES/django.po
+++ b/projectarchive/locale/nb/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-13 23:06+0100\n"
+"POT-Creation-Date: 2024-04-11 12:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: projectarchive/templates/projectarchive/edit_article.html:12
+#: projectarchive/templates/projectarchive/edit_article.html:10
 msgid "Rediger prosjektartikkel"
 msgstr ""
 

--- a/website/locale/en/LC_MESSAGES/django.po
+++ b/website/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-13 23:06+0100\n"
+"POT-Creation-Date: 2024-04-11 12:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -417,6 +417,14 @@ msgstr "Recent news"
 msgid "Siste arrangementer"
 msgstr "Recent events"
 
+#: website/templates/website/inputs/markdown.html:9
+msgid ""
+"Bare markdown støttes i dette feltet, html blir returnert som plaintext. "
+"Bilder kan legges til ved drag-and-drop."
+msgstr ""
+"Only markdown is supported in this field. HTML is returned as plaintext."
+"Images can be added as drag-and-drop."
+
 #: website/templates/website/rules.html:11
 msgid "Nøvendig informasjon og regler for bruk av verkstedet og diverse utstyr"
 msgstr "Necessary information and rules for the workshop and its equipment"
@@ -464,32 +472,3 @@ msgstr "here"
 msgid "JEG HAR LEST, FORSTÅTT OG GODTAR VILKÅRENE"
 msgstr "I HAVE READ, UNDERSTOOD, AND ACCEPTED THE TERMS"
 
-#, fuzzy
-#~| msgid "Siste nytt"
-#~ msgid "Siste internnytt"
-#~ msgstr "Recent news"
-
-#~ msgid "Her var det intetnytt"
-#~ msgstr "Nothinng new here"
-
-#, fuzzy
-#~| msgid "Siste arrangementer"
-#~ msgid "Siste interne arrangementer"
-#~ msgstr "Recent events"
-
-#, fuzzy
-#~| msgid "Siste arrangementer"
-#~ msgid "Ingen interne arrangementer"
-#~ msgstr "Recent events"
-
-#~ msgid "Åpne lånesøknader"
-#~ msgstr "Open item loans"
-
-#~ msgid "Ingen lånesøknader"
-#~ msgstr "No item loans"
-
-#~ msgid "Lånesøknader"
-#~ msgstr "Item loans"
-
-#~ msgid "Bildegalleri"
-#~ msgstr "Gallery"

--- a/website/locale/nb/LC_MESSAGES/django.po
+++ b/website/locale/nb/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-13 23:06+0100\n"
+"POT-Creation-Date: 2024-04-11 12:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -381,6 +381,12 @@ msgstr ""
 
 #: website/templates/website/index.html:86
 msgid "Siste arrangementer"
+msgstr ""
+
+#: website/templates/website/inputs/markdown.html:9
+msgid ""
+"Bare markdown støttes i dette feltet, html blir returnert som plaintext. "
+"Bilder kan legges til ved drag-and-drop."
 msgstr ""
 
 #: website/templates/website/rules.html:11

--- a/website/templatetags/includeslots.py
+++ b/website/templatetags/includeslots.py
@@ -23,7 +23,6 @@ class SlotsIncludedNode(IncludeNode):
 
     def render(self, context):
         for slot in self.slots:
-            print("slot", slot)
             context[slot.name] = slot.nodelist.render(context)
         return super().render(context)
 


### PR DESCRIPTION
Adds several forgotten translations.
Adds d.m.y as an accepted format. It is assumed on Norwegian, but on the English version it has to be added explicitly.
Not really the best solution, but I just want this to work
